### PR TITLE
Update MainScenario_10_en-CAB: Tags Added

### DIFF
--- a/text_DeepL/MainScenario_10_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--8135272822476399567.txt
+++ b/text_DeepL/MainScenario_10_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--8135272822476399567.txt
@@ -30,7 +30,7 @@
    [1]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199232
-     1 string m_Localized = "Go, take back our lands from the hands of the imperial army!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Go, take back our lands from the hands of the imperial army!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -38,7 +38,7 @@
    [2]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199233
-     1 string m_Localized = "Go! Go! Go, go, go, go, go, go!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Go! Go! Go, go, go, go, go, go!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -1782,7 +1782,7 @@
    [220]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365083
-     1 string m_Localized = "Let's go! Let's finish this fight!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Let's go! Let's finish this fight!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -1990,7 +1990,7 @@
    [246]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365109
-     1 string m_Localized = "More importantly, you're the one who's been going around too much on your own, aren't you? Calm down a little ......."
+     1 string m_Localized = "More importantly, you're the one who's been going around too much on your own, aren't you? Calm down a little .......<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2638,7 +2638,7 @@
    [327]
     0 TableEntryData data
      0 SInt64 m_Id = 2880753700
-     1 string m_Localized = "You beast-faced one!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>You beast-faced one!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2774,7 +2774,7 @@
    [344]
     0 TableEntryData data
      0 SInt64 m_Id = 2884947975
-     1 string m_Localized = "Wait!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Wait!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2782,7 +2782,7 @@
    [345]
     0 TableEntryData data
      0 SInt64 m_Id = 2884947976
-     1 string m_Localized = "See you soon, Guardian."
+     1 string m_Localized = "See you soon, Guardian.<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2886,7 +2886,7 @@
    [358]
     0 TableEntryData data
      0 SInt64 m_Id = 2884947989
-     1 string m_Localized = "Aldrick!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Aldrick!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2982,7 +2982,7 @@
    [370]
     0 TableEntryData data
      0 SInt64 m_Id = 2884948001
-     1 string m_Localized = "It is foolish to keep this technology lying in ancient ruins!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>It is foolish to keep this technology lying in ancient ruins!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2990,7 +2990,7 @@
    [371]
     0 TableEntryData data
      0 SInt64 m_Id = 2884948002
-     1 string m_Localized = "And that you dwarfs who don't understand this are blocking my way! You are a fool to keep that technology in those ancient ruins!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>And that you dwarfs who don't understand this are blocking my way! You are a fool to keep that technology in those ancient ruins!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3014,7 +3014,7 @@
    [374]
     0 TableEntryData data
      0 SInt64 m_Id = 2884948005
-     1 string m_Localized = "Don't lie! What did you do with the lives of the people of Yael's village?"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Don't lie! What did you do with the lives of the people of Yael's village?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3038,7 +3038,7 @@
    [377]
     0 TableEntryData data
      0 SInt64 m_Id = 2884948008
-     1 string m_Localized = "I don't trust anything you say!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>I don't trust anything you say!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3054,7 +3054,7 @@
    [379]
     0 TableEntryData data
      0 SInt64 m_Id = 2884948010
-     1 string m_Localized = "So you think this is a lie? You think this power is a lie?"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>So you think this is a lie? You think this power is a lie?<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3062,7 +3062,7 @@
    [380]
     0 TableEntryData data
      0 SInt64 m_Id = 2884948011
-     1 string m_Localized = "Let me see your proof. ！！！！"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Let me see your proof. ！！！！"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3070,7 +3070,7 @@
    [381]
     0 TableEntryData data
      0 SInt64 m_Id = 2884948012
-     1 string m_Localized = "What is that?"
+     1 string m_Localized = "What is that?<autosubmit=0.75>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3310,7 +3310,7 @@
    [411]
     0 TableEntryData data
      0 SInt64 m_Id = 2889142299
-     1 string m_Localized = "Noah!"
+     1 string m_Localized = "Noah!<autosubmit=1>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3318,7 +3318,7 @@
    [412]
     0 TableEntryData data
      0 SInt64 m_Id = 2889142300
-     1 string m_Localized = "Come on!"
+     1 string m_Localized = "Come on!<autosubmit=1>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3326,7 +3326,7 @@
    [413]
     0 TableEntryData data
      0 SInt64 m_Id = 2889142301
-     1 string m_Localized = "Oh, here we go. ！！！！！"
+     1 string m_Localized = "Oh, here we go. ！！！！！<autosubmit=1.3>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3334,7 +3334,7 @@
    [414]
     0 TableEntryData data
      0 SInt64 m_Id = 2889142302
-     1 string m_Localized = "My ...... sought after ...... brilliance is ......"
+     1 string m_Localized = "My ...... sought after ...... brilliance is ......<autosubmit=2.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3366,7 +3366,7 @@
    [418]
     0 TableEntryData data
      0 SInt64 m_Id = 2889142306
-     1 string m_Localized = "Pumipmi-Pumi-!"
+     1 string m_Localized = "Pumipmi-Pumi-!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3390,7 +3390,7 @@
    [421]
     0 TableEntryData data
      0 SInt64 m_Id = 2889142309
-     1 string m_Localized = "Oh, no! Let's get out of here!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Oh, no! Let's get out of here!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4894,7 +4894,7 @@
    [609]
     0 TableEntryData data
      0 SInt64 m_Id = 2905919529
-     1 string m_Localized = "What? That's what?"
+     1 string m_Localized = "What? That's what?<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5478,7 +5478,7 @@
    [682]
     0 TableEntryData data
      0 SInt64 m_Id = 2914308117
-     1 string m_Localized = "Oh! You're not General Electra, are you? No, no, no, no, no, no, no, no, no, no, no, no, no, no! The General is mine!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Oh! You're not General Electra, are you? No, no, no, no, no, no, no, no, no, no, no, no, no, no! The General is mine!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -7462,7 +7462,7 @@
    [930]
     0 TableEntryData data
      0 SInt64 m_Id = 2943668232
-     1 string m_Localized = "Eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ！！！！ What, what are you talking about! No, no, no, Noah! Ugh, no! Really? Really, really?"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ！！！！ What, what are you talking about! No, no, no, Noah! Ugh, no! Really? Really, really?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -7742,7 +7742,7 @@
    [965]
     0 TableEntryData data
      0 SInt64 m_Id = 2943668267
-     1 string m_Localized = "No, no! No, no! What you wanted to say was ......!"
+     1 string m_Localized = "No, no! No, no! What you wanted to say was ......!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -10654,7 +10654,7 @@
    [1329]
     0 TableEntryData data
      0 SInt64 m_Id = 2977222665
-     1 string m_Localized = "Carrie."
+     1 string m_Localized = "Carrie.<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -10662,7 +10662,7 @@
    [1330]
     0 TableEntryData data
      0 SInt64 m_Id = 2977222666
-     1 string m_Localized = "It's still a lie!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>It's still a lie!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -13350,7 +13350,7 @@
    [1666]
     0 TableEntryData data
      0 SInt64 m_Id = 3010777116
-     1 string m_Localized = "Keep your head in the game, Noah!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Keep your head in the game, Noah!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -16262,7 +16262,7 @@
    [2030]
     0 TableEntryData data
      0 SInt64 m_Id = 3048525842
-     1 string m_Localized = "What, ...... gently teaching him ......?"
+     1 string m_Localized = "What, ...... gently teaching him ......?<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -16302,7 +16302,7 @@
    [2035]
     0 TableEntryData data
      0 SInt64 m_Id = 3048525847
-     1 string m_Localized = "I can only heal you with a smile ......."
+     1 string m_Localized = "I can only heal you with a smile .......<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -19766,7 +19766,7 @@
    [2468]
     0 TableEntryData data
      0 SInt64 m_Id = 3090468875
-     1 string m_Localized = "Oh, Noah is alone in the dusk! What's going on here?"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Oh, Noah is alone in the dusk! What's going on here?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -19942,7 +19942,7 @@
    [2490]
     0 TableEntryData data
      0 SInt64 m_Id = 3090468897
-     1 string m_Localized = "Let's send off tomorrow's departure with a once-in-a-generation play-by-play! And please let us play the triumphant triumph in real life, too!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>Let's send off tomorrow's departure with a once-in-a-generation play-by-play! And please let us play the triumphant triumph in real life, too!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -19958,7 +19958,7 @@
    [2492]
     0 TableEntryData data
      0 SInt64 m_Id = 3090468899
-     1 string m_Localized = "And the Alliance leader smiled a fresh smile, as if he was confident of victory in tomorrow's battle, and staring into the distance, he renewed his resolve!"
+     1 string m_Localized = "<shake duration=0.4 strength=17.5>And the Alliance leader smiled a fresh smile, as if he was confident of victory in tomorrow's battle, and staring into the distance, he renewed his resolve!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -22590,7 +22590,7 @@
    [2821]
     0 TableEntryData data
      0 SInt64 m_Id = 3119829034
-     1 string m_Localized = "Then you and your kitty can go to ......."
+     1 string m_Localized = "Then you and your kitty can go to .......<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -23574,7 +23574,7 @@
    [2944]
     0 TableEntryData data
      0 SInt64 m_Id = 3132411931
-     1 string m_Localized = "Well, I used to do that, so I can help you. ......!"
+     1 string m_Localized = "Well, I used to do that, so I can help you. ......!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)


### PR DESCRIPTION
Tags added based on version MainScenario_10_ja-CAB.txt:
- shake duration
- strength
- autosubmit

The following codes:
- SInt64 m_Id = 2880753701
- SInt64 m_Id = 2889142283
- SInt64 m_Id = 2893336616
- SInt64 m_Id = 2901725216
- SInt64 m_Id = 2905919494
- SInt64 m_Id = 2914308101
- SInt64 m_Id = 2935279617
- SInt64 m_Id = 2973028392
- SInt64 m_Id = 2998194207
- SInt64 m_Id = 2998194215
- SInt64 m_Id = 3040137223
- SInt64 m_Id = 3065303042
- SInt64 m_Id = 3073691661
- SInt64 m_Id = 3082080279
- SInt64 m_Id = 3124023323

were not modified. I am not sure how to add the Tag: ruby.

Special Case:
- SInt64 m_Id = 2884948002 (Added: shake duration, strength, autosubmit. Omitted: ruby)