### PR TITLE
Update HeroTalk_ch_00160_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--176…

### DIFF
--- a/text_DeepL/HeroTalk_ch_00160_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--1765468253659387797.txt
+++ b/text_DeepL/HeroTalk_ch_00160_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--1765468253659387797.txt
@@ -574,7 +574,7 @@
    [69]
     0 TableEntryData data
      0 SInt64 m_Id = 2763313174
-     1 string m_Localized = "You think that's a ship?""
+     1 string m_Localized = "You think that's a ship?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -758,7 +758,7 @@
    [92]
     0 TableEntryData data
      0 SInt64 m_Id = 2767507471
-     1 string m_Localized = "What is the Highway Ruins Road?""
+     1 string m_Localized = "What is the Highway Ruins Road?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)


### PR DESCRIPTION
…5468253659387797.txt

Deleted 2 extra quotations on line 92 and 69. Not sure if they were causing others parse erros since I couldn't recreate any parse errors with the files.