### PR TITLE
Update HeroTalk_ch_00160_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--176…

### DIFF
--- a/text_DeepL/HeroTalk_ch_00160_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--1765468253659387797.txt
+++ b/text_DeepL/HeroTalk_ch_00160_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--1765468253659387797.txt
@@ -1272,5 +1272,3 @@
   0 vector RefIds
    1 Array Array
     0 int size = 0
-
-


### PR DESCRIPTION
…5468253659387797.txt

Empty lines on the bottom cause the parse error I think not sure how they even got there....