### PR TITLE
Update HeroTalk_ch_00150_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--877…

### DIFF
--- a/text_DeepL/HeroTalk_ch_00150_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--8774124211816196165
+++ b/text_DeepL/HeroTalk_ch_00150_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--8774124211816196165
@@ -1272,5 +1272,3 @@
   0 vector RefIds
    1 Array Array
     0 int size = 0
-
-


### PR DESCRIPTION
…4124211816196165

Empty lines on the bottom cause the parse error I think not sure how they even got there....