### PR TITLE
Update MainScenario_02_en - Edit (First Pass) Completed

### DIFF
--- a/text_DeepL/MainScenario_02_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--5619663750649154153.txt
+++ b/text_DeepL/MainScenario_02_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--5619663750649154153.txt
@@ -238,7 +238,7 @@
    [27]
     0 TableEntryData data
      0 SInt64 m_Id = 2796867610
-     1 string m_Localized = "Since its your home village, I'm sure you know your way around."
+     1 string m_Localized = "Since it's your home village, I'm sure you know your way around."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -262,7 +262,7 @@
    [30]
     0 TableEntryData data
      0 SInt64 m_Id = 2796867613
-     1 string m_Localized = "That's true, its been a quite a while since I've seen Leene..."
+     1 string m_Localized = "That's true, it's been a quite a while since I've seen Leene..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -334,7 +334,7 @@
    [39]
     0 TableEntryData data
      0 SInt64 m_Id = 2801061895
-     1 string m_Localized = "Well then, let's go see Nowa's home village. Its on the mountain road northwest of here, right?"
+     1 string m_Localized = "Well then, let's go see Nowa's home village. It's on the mountain road northwest of here, right?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -518,7 +518,7 @@
    [62]
     0 TableEntryData data
      0 SInt64 m_Id = 2805256205
-     1 string m_Localized = "Yeah, its been a while since I've seen Leene."
+     1 string m_Localized = "Yeah, it's been a while since I've seen Leene."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -822,7 +822,7 @@
    [100]
     0 TableEntryData data
      0 SInt64 m_Id = 2805256243
-     1 string m_Localized = "Its fine, its fine. Its all fine.\nIf I can see you're doing well, that's all I need to be happy."
+     1 string m_Localized = "It's fine, it's fine. It's all fine.\nAs long as I can see you're doing well, that's all I need to be happy."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -1294,7 +1294,7 @@
    [159]
     0 TableEntryData data
      0 SInt64 m_Id = 2813644803
-     1 string m_Localized = "Hmph, its fine as long as word spreads that there's trouble near the border."
+     1 string m_Localized = "Hmph, it's fine as long as word spreads that there's trouble near the border."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -1414,7 +1414,7 @@
    [174]
     0 TableEntryData data
      0 SInt64 m_Id = 2813644818
-     1 string m_Localized = "Hmph, its fine as long as word spreads that there's trouble near the border!"
+     1 string m_Localized = "Hmph, it's fine as long as word spreads that there's trouble near the border!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -1974,7 +1974,7 @@
    [244]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033409
-     1 string m_Localized = "That's not the end of it.\nIts said that the Eltisweiss Watch are the ones behind the attacks."
+     1 string m_Localized = "That's not the end of it.\nIt's said that the Eltisweiss Watch are the ones behind the attacks."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -1990,7 +1990,7 @@
    [246]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033411
-     1 string m_Localized = "Oh, its not me saying it. That's just what the rumours are."
+     1 string m_Localized = "Oh, it's not me saying it. That's just what the rumours are."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2286,7 +2286,7 @@
    [283]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033448
-     1 string m_Localized = "Gao and Nowa, its good to see you here."
+     1 string m_Localized = "Gao and Nowa, it's good to see you here."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2310,7 +2310,7 @@
    [286]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033451
-     1 string m_Localized = "Ohhh? This sounds like its going to be a serious problem."
+     1 string m_Localized = "Ohhh? This sounds like it's going to be a serious problem."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2958,7 +2958,7 @@
    [367]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422051
-     1 string m_Localized = "What the hell is that? Its all hogwash!\nWhy I oughta..."
+     1 string m_Localized = "What the hell is that? It's all hogwash!\nWhy I oughta..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3638,7 +3638,7 @@
    [452]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810656
-     1 string m_Localized = "Sorry, for now there's no explanation nor justification.\nIt <i>is</i> outrageous though."
+     1 string m_Localized = "Sorry, for now, there's no explanation nor justification.\nIt <i>is</i> outrageous though."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3686,7 +3686,7 @@
    [458]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810662
-     1 string m_Localized = "First, we have to tell Yumir."
+     1 string m_Localized = "First thing's first, we need to report to Ymir."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3694,7 +3694,7 @@
    [459]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810663
-     1 string m_Localized = "War ...... or ......?"
+     1 string m_Localized = "So... it's war...?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3702,7 +3702,7 @@
    [460]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810664
-     1 string m_Localized = "You're back, acting platoon leader. I was just on my way to report to the young lady. Just in time, please come with me."
+     1 string m_Localized = "You're back, Acting Sqaud Leader.\nI was just on my way to meet to the Lady.\nJust as well, please come along."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3710,7 +3710,7 @@
    [461]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810665
-     1 string m_Localized = "Oh, okay."
+     1 string m_Localized = "Yeah, alright."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3718,7 +3718,7 @@
    [462]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004928
-     1 string m_Localized = "I see... ...... about a legion of weapons and a few months worth of food?"
+     1 string m_Localized = "I see.\nEnough weapons to arm a legion, and a few months worth of provisions?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3726,7 +3726,7 @@
    [463]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004929
-     1 string m_Localized = "Chapelle, the general of the expedition,......, is exaggerating when he talks about handing over the culprits, as they say."
+     1 string m_Localized = "Seems a bit much if all General Chapell wants is to capture some raiders."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3734,7 +3734,7 @@
    [464]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004930
-     1 string m_Localized = "We have information that Duke Aldrick is on his way there with an army to receive the Northphalian territory that was recently agreed upon."
+     1 string m_Localized = "We've received intel that Duke Aldric is leading an army to Norsfaria to requisition from their newly annexed territory."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3742,7 +3742,7 @@
    [465]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004931
-     1 string m_Localized = "As for the request for reinforcements to Euclis, there seems to be some disagreement within the country."
+     1 string m_Localized = "As for the request for reinforcements from Euchrisse, opinions within their nation seem to be divided."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3750,7 +3750,7 @@
    [466]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004932
-     1 string m_Localized = "There is a strong opinion, especially from the nobility senators, that we should not get involved in the problems between Eltisweiss and the Empire. ......"
+     1 string m_Localized = "There is a strong sentiment, especially within their House of Lords, that they shouldn't get involved in what is, in their eyes, a dispute between Eltisweiss and the Empire."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3758,7 +3758,7 @@
    [467]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004933
-     1 string m_Localized = "There is a lot of money at stake in the Northfalia handover, and the nobles seem to be afraid that it will be scrapped."
+     1 string m_Localized = "There is a lot of money at stake in the Norsfaria handover, and their Lords are fearful that the agreement will fall through."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3766,7 +3766,7 @@
    [468]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004934
-     1 string m_Localized = "The monarch Yumma-Sharias is willing to send reinforcements, but he is not ready to make a decision right away because of the nobles."
+     1 string m_Localized = "King Euma Siarith seemed to be amenable to sending reinforcements, but he is unwilling to make any commitments right now due to council from the Lords."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3774,7 +3774,7 @@
    [469]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004935
-     1 string m_Localized = "Yumma would probably do so. But the nobles are in it for the money at hand,...... and if that's also the Duke's calculation, he's a really nasty man."
+     1 string m_Localized = "That sounds like Euma. But the nobles are far too interested in the money in front of them...\nIf that was also part of the Duke's plans, then he truly <i>is</i> devious."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3782,7 +3782,7 @@
    [470]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004936
-     1 string m_Localized = "I didn't expect immediate reinforcements, ...... but there is hope."
+     1 string m_Localized = "I wasn't expecting reinforcements anytime soon. But, there is still hope."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3790,7 +3790,7 @@
    [471]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004937
-     1 string m_Localized = "Then it looks like we'll have to stay holed up here and wait for reinforcements in the meantime. I guess we should be prepared to hang on for a few months or even six months."
+     1 string m_Localized = "Then it looks like we'll have hunker down here while waiting for those reinforcements.\nI'd guess we would need to hold out for a few-... no, maybe six months."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3798,7 +3798,7 @@
    [472]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004938
-     1 string m_Localized = "We have already stocked up on food in Eltisweiss, as your daughter has instructed us to do before. It should last a year."
+     1 string m_Localized = "We have already stocked up on food in Eltisweiss, as per the Lady's orders. Our stores should last us about a year."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3806,7 +3806,7 @@
    [473]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004939
-     1 string m_Localized = "Time is on our side. The longer it goes on, the more the clueless will see the ambitions of the empire."
+     1 string m_Localized = "Time is on our side. The longer this drags on, the more those clueless nobles will be forced to witness the true ambitions of the Empire."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3814,7 +3814,7 @@
    [474]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004940
-     1 string m_Localized = "If we manage to prevent the first battle, we'll be able to defend ourselves. Everyone, please."
+     1 string m_Localized = "So, first we fend off whatever the Empire throws at us in their initial assault, and then we weather the long siege.\nI'm counting on you all."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3822,7 +3822,7 @@
    [475]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004941
-     1 string m_Localized = "Yes, of course!"
+     1 string m_Localized = "Yes! You can count on us!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3830,7 +3830,7 @@
    [476]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004942
-     1 string m_Localized = "To war: ............."
+     1 string m_Localized = "So it's war..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3838,7 +3838,7 @@
    [477]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004943
-     1 string m_Localized = "Oh, yes, of course!"
+     1 string m_Localized = "Yes! You can count on us!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3846,7 +3846,7 @@
    [478]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004944
-     1 string m_Localized = "Oh, ............."
+     1 string m_Localized = "Mmh..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3854,7 +3854,7 @@
    [479]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004945
-     1 string m_Localized = "Yes, it was Nowa. Yumir, let him have a part of the squad."
+     1 string m_Localized = "Ahh, you're Nowa, yes?\nYmir, please give him command of a squad."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3870,7 +3870,7 @@
    [481]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004947
-     1 string m_Localized = "Sure, he's temporarily the platoon leader at Gaou's request, but he's only a substitute. ......"
+     1 string m_Localized = "Sure, he's been made a temporary squad leader at Garr's request, but he's still only a deputy-"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3878,7 +3878,7 @@
    [482]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004948
-     1 string m_Localized = "He seems to be willing to do it, and if Gaou and the others are with him, it won't be a problem."
+     1 string m_Localized = "He seems eager to do it, and I'm sure there won't be any problems since Garr and the others will be watching over him."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3886,7 +3886,7 @@
    [483]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004949
-     1 string m_Localized = "Oh, that's good."
+     1 string m_Localized = "Yeah, that's fine by me."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3894,7 +3894,7 @@
    [484]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004950
-     1 string m_Localized = "Yes, ...... to fight, you need a story."
+     1 string m_Localized = "Indeed...\nYou need a good story if you want to fight a war."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3902,7 +3902,7 @@
    [485]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004951
-     1 string m_Localized = "To war ............."
+     1 string m_Localized = "So it's war..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3918,7 +3918,7 @@
    [487]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004953
-     1 string m_Localized = "You were Nowa, weren't you?"
+     1 string m_Localized = "Your name was, Nowa, wasn't it?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3926,7 +3926,7 @@
    [488]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004954
-     1 string m_Localized = "Yumir, let him take the squad."
+     1 string m_Localized = "Ymir, give him command of a squad."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3934,7 +3934,7 @@
    [489]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004955
-     1 string m_Localized = "What ...... is that ......?"
+     1 string m_Localized = "Huh? Are you-...??"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3942,7 +3942,7 @@
    [490]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004956
-     1 string m_Localized = "Sure, he's temporarily the platoon leader at Gaou's request, but he's only a deputy. ......"
+     1 string m_Localized = "Sure, he's been made a temporary squad leader at Garr's request, but he's still only a deputy-"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3950,7 +3950,7 @@
    [491]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004957
-     1 string m_Localized = "If Gao and the others are with him, it's not a problem, is it?"
+     1 string m_Localized = "Surely there won't be any problems since Garr and the others will be watching over him?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3958,7 +3958,7 @@
    [492]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004958
-     1 string m_Localized = "Yeah, that's fine."
+     1 string m_Localized = "Yeah, that's fine by me."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3966,7 +3966,7 @@
    [493]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004959
-     1 string m_Localized = "Yes, ...... there's a story to fight."
+     1 string m_Localized = "Indeed...\nYou need a good story if you want to fight a war."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3974,7 +3974,7 @@
    [494]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004960
-     1 string m_Localized = "Is it the ...... who stood up to fight even though he lost his birthplace due to the dastardly raids of the empire?"
+     1 string m_Localized = "'<i>The boy who rose up to fight after losing his birthplace to a despicable Imperial raid.</i>'\nIs that how it goes?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3982,7 +3982,7 @@
    [495]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004961
-     1 string m_Localized = "Something like that, start a rumor."
+     1 string m_Localized = "Something like that. Please spread the word."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3990,7 +3990,7 @@
    [496]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004962
-     1 string m_Localized = "I didn't actually lose it, but ......."
+     1 string m_Localized = "The village isn't actually lost though..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3998,7 +3998,7 @@
    [497]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004963
-     1 string m_Localized = "It's just a bit of a stunt."
+     1 string m_Localized = "It's just our own little rendition."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4006,7 +4006,7 @@
    [498]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004964
-     1 string m_Localized = "Miss ......."
+     1 string m_Localized = "My Lady..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4014,7 +4014,7 @@
    [499]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004965
-     1 string m_Localized = "What?"
+     1 string m_Localized = "What is it?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4022,7 +4022,7 @@
    [500]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004966
-     1 string m_Localized = "You look bad. ......"
+     1 string m_Localized = "You have a detestable countenance about you..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4030,7 +4030,7 @@
    [501]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004967
-     1 string m_Localized = "I can't help it. I'm desperate."
+     1 string m_Localized = "I can't help it. I'm desperate for anything here."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4038,7 +4038,7 @@
    [502]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004968
-     1 string m_Localized = "Oh, I was just about to call for you! I've heard it's a war council meeting! I think they're finally here!"
+     1 string m_Localized = "Oh, I was just about to get you!\nThere's somekind of war council happening! I think they're finally here!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4046,7 +4046,7 @@
    [503]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004969
-     1 string m_Localized = "It's been two weeks since the scouting ...... finally ......"
+     1 string m_Localized = "It's been two weeks since the reconnaissance. Finally..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4054,7 +4054,7 @@
    [504]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004970
-     1 string m_Localized = "Will this be Nowa's first battle? Let's go to Gao and the others!"
+     1 string m_Localized = "Will this be Nowa's first big battle?!\nLet's go meet up with Garr and the others!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4062,7 +4062,7 @@
    [505]
     0 TableEntryData data
      0 SInt64 m_Id = 2843004971
-     1 string m_Localized = "Hey, you! I heard the imperial army showed up. Don't go out there."
+     1 string m_Localized = "Hey, you! They say the Imperial army showed up! Don't go out there!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4070,7 +4070,7 @@
    [506]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199232
-     1 string m_Localized = "Hey, hey, Nowa. You don't have to go to the war council, do you?"
+     1 string m_Localized = "Hey, hey, Nowa. Don't we have a war council to go to?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4078,7 +4078,7 @@
    [507]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199233
-     1 string m_Localized = "You're here, Nowa."
+     1 string m_Localized = "There you are, Nowa."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4086,7 +4086,7 @@
    [508]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199234
-     1 string m_Localized = "We have information that the imperial army has begun to advance. I'm going to ask you to take your place in the defensive battle."
+     1 string m_Localized = "We've received intel that the Imperial army has begun its advance. Please take your assigned defensive positions."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4094,7 +4094,7 @@
    [509]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199235
-     1 string m_Localized = "Are you ready to go?"
+     1 string m_Localized = "I trust you are ready?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4110,7 +4110,7 @@
    [511]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199237
-     1 string m_Localized = "Wait a minute."
+     1 string m_Localized = "Give me a minute."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4118,7 +4118,7 @@
    [512]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199238
-     1 string m_Localized = "Wait a minute... - Yeah, let's go!"
+     1 string m_Localized = "Yeah, let's go!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4126,7 +4126,7 @@
    [513]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199239
-     1 string m_Localized = "We have to win this battle ......."
+     1 string m_Localized = "We <i>have</i> to win this battle..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4142,7 +4142,7 @@
    [515]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199241
-     1 string m_Localized = "Don't get too worked up, it should be a long fight."
+     1 string m_Localized = "Don't get too carried away, this looks like it's going to be a long battle."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4158,7 +4158,7 @@
    [517]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199243
-     1 string m_Localized = "We won't be defeated by the imperial army!"
+     1 string m_Localized = "We won't lose to the Imperial army!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4174,7 +4174,7 @@
    [519]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199245
-     1 string m_Localized = "Wait a minute."
+     1 string m_Localized = "Give me a minute."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4190,7 +4190,7 @@
    [521]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199247
-     1 string m_Localized = "What can I do for you? Hurry up and get ready."
+     1 string m_Localized = "You got some tasks to take care of? Well, hurry it up."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4198,7 +4198,7 @@
    [522]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199248
-     1 string m_Localized = "We're all set. I'll be at my post."
+     1 string m_Localized = "I trust you're ready? Get to your post."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4206,7 +4206,7 @@
    [523]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199249
-     1 string m_Localized = "Oh, let's go!"
+     1 string m_Localized = "Yeah, let's go!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4214,7 +4214,7 @@
    [524]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199250
-     1 string m_Localized = "Wait a minute."
+     1 string m_Localized = "Give me a minute."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4230,7 +4230,7 @@
    [526]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199252
-     1 string m_Localized = "Hurry up."
+     1 string m_Localized = "Hurry it up."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4238,7 +4238,7 @@
    [527]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199253
-     1 string m_Localized = "Hmm? I wonder if it's okay, Nowa-kun. Did I forget something?"
+     1 string m_Localized = "Hmm? Are you okay, Nowa? Did you forget something?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4254,7 +4254,7 @@
    [529]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199255
-     1 string m_Localized = "You're not scared of me, are you? Or are you nervous?"
+     1 string m_Localized = "You're not scared, are you? Or, nervous, perhaps?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4262,7 +4262,7 @@
    [530]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199256
-     1 string m_Localized = "I'm fine. We're all here for you, so don't panic."
+     1 string m_Localized = "Don't worry. We're all here with you. Just don't panic."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4270,7 +4270,7 @@
    [531]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199257
-     1 string m_Localized = "Hold fast to your positions. The enemy is a one-man army, but be on your guard."
+     1 string m_Localized = "All squads, defend your assigned posts.\nThe enemy is a single legion, but be on your guard."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4278,7 +4278,7 @@
    [532]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199258
-     1 string m_Localized = "The first battle will cut the momentum. Don't let them in here, not even for a second."
+     1 string m_Localized = "We can blunt their advance in this first battle! Don't let them take a single step inside the walls!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4294,7 +4294,7 @@
    [534]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199260
-     1 string m_Localized = "You see it. It's part of a coalition of nations that threatens the empire. Even a small country can not be overlooked."
+     1 string m_Localized = "You now see before you, one of the many; of the League of Nations that dares to threaten Imperial sovereignty.\nBut, such provocations, even from a nation as small as this, cannot be overlooked."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4310,7 +4310,7 @@
    [536]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199262
-     1 string m_Localized = "Everyone, please!"
+     1 string m_Localized = "Everyone, if you please!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4318,7 +4318,7 @@
    [537]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199263
-     1 string m_Localized = "For the lady's sake, let's do it!"
+     1 string m_Localized = "In the name of our Lady, LET'S GET IT DONE!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4326,7 +4326,7 @@
    [538]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199264
-     1 string m_Localized = "Oh!!!!!!!"
+     1 string m_Localized = "YEEEAAAAAH!!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4334,7 +4334,7 @@
    [539]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199265
-     1 string m_Localized = "We're late. I'm coming in now."
+     1 string m_Localized = "We were delayed. We're joining the battle now."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4342,7 +4342,7 @@
    [540]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199266
-     1 string m_Localized = "Oh, sorry! She ............ is in a bad mood."
+     1 string m_Localized = "S-sorry! She was-I mean, the Rune tank was in a bad mood."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4350,7 +4350,7 @@
    [541]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199267
-     1 string m_Localized = "I'm sorry, she's  in a bad mood."
+     1 string m_Localized = "Hmph. The Kesling boy?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4358,7 +4358,7 @@
    [542]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199268
-     1 string m_Localized = "I'm sorry, she's  in a bad mood with the magic tank."
+     1 string m_Localized = "The Duke seems to have taken notice of him, but he'd better not get in my way."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4366,7 +4366,7 @@
    [543]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199269
-     1 string m_Localized = "Here he comes!"
+     1 string m_Localized = "Here they come!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4382,7 +4382,7 @@
    [545]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199271
-     1 string m_Localized = "I won't let you in!"
+     1 string m_Localized = "We won't let you in!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4390,7 +4390,7 @@
    [546]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199272
-     1 string m_Localized = "Ohhh..! I'll do it!"
+     1 string m_Localized = "YEAH! LET'S DO THIS!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4398,7 +4398,7 @@
    [547]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199273
-     1 string m_Localized = "I won't let you get away with this!"
+     1 string m_Localized = "I won't let you get away with your pathetic lies!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4406,7 +4406,7 @@
    [548]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199274
-     1 string m_Localized = "I'm coming!"
+     1 string m_Localized = "Here I come!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4414,7 +4414,7 @@
    [549]
     0 TableEntryData data
      0 SInt64 m_Id = 2847199275
-     1 string m_Localized = "We will not allow you to try to commit a trivial crime! This is our legitimate right! Come on!"
+     1 string m_Localized = "We <i>WILL</i> have those who invaded the territory of our Empire handed over to us!\nThis is our RIGHT! HAVE AT YOU!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4430,7 +4430,7 @@
    [551]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393537
-     1 string m_Localized = "Lieutenant ......"
+     1 string m_Localized = "Lieutenant..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4438,7 +4438,7 @@
    [552]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393538
-     1 string m_Localized = "Don't worry, I'll be there."
+     1 string m_Localized = "Don't worry, let's go."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4446,7 +4446,7 @@
    [553]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393539
-     1 string m_Localized = "I don't think that's ......!"
+     1 string m_Localized = "Is that who I think it is...!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4454,7 +4454,7 @@
    [554]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393540
-     1 string m_Localized = "I knew it was ............ Nowa or ......."
+     1 string m_Localized = "I knew it... Nowa..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4470,7 +4470,7 @@
    [556]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393542
-     1 string m_Localized = "Damn ......, he's in there!"
+     1 string m_Localized = "Damn it, they got inside the walls!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4478,7 +4478,7 @@
    [557]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393543
-     1 string m_Localized = "Oh, no! No, no, not yet!"
+     1 string m_Localized = "Oh no! But it's not over yet!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4486,7 +4486,7 @@
    [558]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393544
-     1 string m_Localized = "You can't stop it, ...... miss ...... sorry ......"
+     1 string m_Localized = "We couldn't stop them... forgive me... My Lady..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4494,7 +4494,7 @@
    [559]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393545
-     1 string m_Localized = "Damn, these guys, what a persistent bunch!"
+     1 string m_Localized = "Damn them! What a persistent bunch!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4502,7 +4502,7 @@
    [560]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393546
-     1 string m_Localized = "Sorry, I'm just so confident in my waywardness!!!!"
+     1 string m_Localized = "Sorry! We're pretty stubborn when we're in a fight!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4510,7 +4510,7 @@
    [561]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393547
-     1 string m_Localized = "We're almost there. We're almost there, let's get through this!"
+     1 string m_Localized = "Just a little more. Let's power on through!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4518,7 +4518,7 @@
    [562]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393548
-     1 string m_Localized = "We'll hold them off!"
+     1 string m_Localized = "We <i>WILL</i> protect this city!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4526,7 +4526,7 @@
    [563]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393549
-     1 string m_Localized = "Get the hell out of here!"
+     1 string m_Localized = "Just go home already!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4534,7 +4534,7 @@
    [564]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393550
-     1 string m_Localized = "I'm Nowa!"
+     1 string m_Localized = "I AM NOWA!!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4542,7 +4542,7 @@
    [565]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393551
-     1 string m_Localized = "I will definitely protect this place! For everyone's sake! For home!"
+     1 string m_Localized = "We <i>WILL</i> protect this city! For my village, and for everyone!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4550,7 +4550,7 @@
    [566]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393552
-     1 string m_Localized = "Oh!"
+     1 string m_Localized = "YEAAAH!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4558,7 +4558,7 @@
    [567]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393553
-     1 string m_Localized = "Go home!"
+     1 string m_Localized = "Just go home already!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4566,7 +4566,7 @@
    [568]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393554
-     1 string m_Localized = "That's right! Justice will prevail!"
+     1 string m_Localized = "That's right! Justice always prevails!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4574,7 +4574,7 @@
    [569]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393555
-     1 string m_Localized = "I am Nowa!"
+     1 string m_Localized = "I AM NOWA!!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4582,7 +4582,7 @@
    [570]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393556
-     1 string m_Localized = "Oh, oh. You're really into ......."
+     1 string m_Localized = "Uhh... y-yeah...\nThat's the spirit."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4590,7 +4590,7 @@
    [571]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393557
-     1 string m_Localized = "Gghhhh ......."
+     1 string m_Localized = "Nnghh..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4598,7 +4598,7 @@
    [572]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393558
-     1 string m_Localized = "Mr. Chappelle, ......."
+     1 string m_Localized = "Lord Chapell."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4606,7 +4606,7 @@
    [573]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393559
-     1 string m_Localized = "It can't be helped ......, let's get back on track once and for all."
+     1 string m_Localized = "We have no choice...\nSound a strategic withdrawal to reorganise and regroup."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4614,7 +4614,7 @@
    [574]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393560
-     1 string m_Localized = "Pfft, come to me day before tomorrow!"
+     1 string m_Localized = "Heh, don't bother coming back!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4622,7 +4622,7 @@
    [575]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393561
-     1 string m_Localized = "Yes, we did it! The enemy is retreating!"
+     1 string m_Localized = "We... We did it! The enemy is retreating!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4630,7 +4630,7 @@
    [576]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393562
-     1 string m_Localized = "Phew, now we can take a breather."
+     1 string m_Localized = "Phew, I think we can take a breather."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4638,7 +4638,7 @@
    [577]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393563
-     1 string m_Localized = "Well, it looks like it's about time: ......"
+     1 string m_Localized = "Now then, this looks like a suitable time..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4646,7 +4646,7 @@
    [578]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393564
-     1 string m_Localized = "What the ...... and ......."
+     1 string m_Localized = "What in the world...?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4654,7 +4654,7 @@
    [579]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393565
-     1 string m_Localized = "Oh, no, no, no. ......."
+     1 string m_Localized = "It can't be..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4662,7 +4662,7 @@
    [580]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393566
-     1 string m_Localized = "Oh, that's ridiculous. ......"
+     1 string m_Localized = "Im-...impossible..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4670,7 +4670,7 @@
    [581]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393567
-     1 string m_Localized = "It's not a battle just to cut each other's armies down."
+     1 string m_Localized = "The point of warfare is <i>not</i> to smash armies together and cut each other down."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4678,7 +4678,7 @@
    [582]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393568
-     1 string m_Localized = "If you break the heart of man, the will to fight, your soldiers will become nothing more than a bunch of crows. Chasing them is easier than hunting rabbits."
+     1 string m_Localized = "Break the heart of the man, the will to fight, and hardened soldiers will be reduced to mere rabble. They will flee like scared rabbits."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4686,7 +4686,7 @@
    [583]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393569
-     1 string m_Localized = "Kuku ............ from Northfalia to here with the whole army ......?"
+     1 string m_Localized = "Damn... he's marched his <i>entire army</i> from Norsfaria to here??"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4694,7 +4694,7 @@
    [584]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393570
-     1 string m_Localized = "Well, such information has been ...... so far."
+     1 string m_Localized = "But, we've received no such intel..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4702,7 +4702,7 @@
    [585]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393571
-     1 string m_Localized = "It's easier when you feel relaxed and victorious."
+     1 string m_Localized = "It's much easier to break one's will when one is confident in victory."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4710,7 +4710,7 @@
    [586]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393572
-     1 string m_Localized = "A large army is just that, a weapon of terror."
+     1 string m_Localized = "An overwhelming force is just that, a weapon of terror."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4718,7 +4718,7 @@
    [587]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393573
-     1 string m_Localized = "The whole army must advance in unison. Only march with fear, as through a no man's land."
+     1 string m_Localized = "All troops, advance in unison. March as if through empty plains. Become terror incarnate."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4726,7 +4726,7 @@
    [588]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393574
-     1 string m_Localized = "Hee, hee, hee!"
+     1 string m_Localized = "Ee...EEEYAH!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4734,7 +4734,7 @@
    [589]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393575
-     1 string m_Localized = "Oh, no. ............"
+     1 string m_Localized = "This can't be..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4742,7 +4742,7 @@
    [590]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393576
-     1 string m_Localized = "Ow!"
+     1 string m_Localized = "Shit...!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4750,7 +4750,7 @@
    [591]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393577
-     1 string m_Localized = "No, no, no, no!"
+     1 string m_Localized = "EEEK! IT'S HOPELESS!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4758,7 +4758,7 @@
    [592]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393578
-     1 string m_Localized = "We've got to get out of here!"
+     1 string m_Localized = "RUNNN!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4766,7 +4766,7 @@
    [593]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393579
-     1 string m_Localized = "Shit, we've gotta get out of here!"
+     1 string m_Localized = "Shit, we need to leave too!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4774,7 +4774,7 @@
    [594]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393580
-     1 string m_Localized = "But!<autosubmit=0.5>"
+     1 string m_Localized = "BUT-!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4782,7 +4782,7 @@
    [595]
     0 TableEntryData data
      0 SInt64 m_Id = 2851393581
-     1 string m_Localized = "But! But! Death in vain is not a warrior's death! You've got to survive, even if you're a fool!"
+     1 string m_Localized = "A pointless death is no death for a <i>WARRIOR</i>!!\nYou <i>MUST</i> to survive, even if it means appearing unsightly!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4790,7 +4790,7 @@
    [596]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587840
-     1 string m_Localized = "Yes, that's right! That's not justice!"
+     1 string m_Localized = "Yes, that's right! That isn't justice!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4814,7 +4814,7 @@
    [599]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587843
-     1 string m_Localized = "No, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no!"
+     1 string m_Localized = "NOT THAT WAY!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4822,7 +4822,7 @@
    [600]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587844
-     1 string m_Localized = "No, no, no! No, no, no, no, no, no, no, no, no, no, no, no, no, no!"
+     1 string m_Localized = "No no! Not this way!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4830,7 +4830,7 @@
    [601]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587845
-     1 string m_Localized = "Damn it, ......, it's ...... now."
+     1 string m_Localized = "Shit... not now."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4838,7 +4838,7 @@
    [602]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587846
-     1 string m_Localized = "Nowa! Gao!"
+     1 string m_Localized = "Nowa! Garr!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4846,7 +4846,7 @@
    [603]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587847
-     1 string m_Localized = "Liang!"
+     1 string m_Localized = "Lian!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4862,7 +4862,7 @@
    [605]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587849
-     1 string m_Localized = "Yes! Yumir went towards the other soldiers and the young lady's house! Let's go!"
+     1 string m_Localized = "Yes! Ymir went with some soldiers to our Lady's manor! Let's head there too!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4870,7 +4870,7 @@
    [606]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587850
-     1 string m_Localized = "We're going to take control of the place. Don't make a fool of yourself in front of the Duke!"
+     1 string m_Localized = "Seize control of the city!\nAnd don't do anything unseemly in front of the Duke!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4894,7 +4894,7 @@
    [609]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587853
-     1 string m_Localized = "No, no, not that way! Go to Mr. Perrier's mansion!"
+     1 string m_Localized = "No, not that way! Head to Miss Perrielle's manor!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4910,7 +4910,7 @@
    [611]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587855
-     1 string m_Localized = "Hey, there's a bunch of Union dogs there! Come on!"
+     1 string m_Localized = "Hey, there's a bunch of League lapdogs over there! Have at them!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4926,7 +4926,7 @@
    [613]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587857
-     1 string m_Localized = "Yes! - Go to ......."
+     1 string m_Localized = "SHIT!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4934,7 +4934,7 @@
    [614]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587858
-     1 string m_Localized = "No, no, no, no! Let's go, let's go, let's go, let's go!"
+     1 string m_Localized = "It's useless! We have to go!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4950,7 +4950,7 @@
    [616]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587860
-     1 string m_Localized = "Come on, Gao, Nowa, Liang!"
+     1 string m_Localized = "There you are, Gao, Nowa, Lian!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4958,7 +4958,7 @@
    [617]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587861
-     1 string m_Localized = "Where's Yumir?"
+     1 string m_Localized = "Where's Ymir?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4974,7 +4974,7 @@
    [619]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587863
-     1 string m_Localized = "What's going on out there?"
+     1 string m_Localized = "What's the situation out there?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4982,7 +4982,7 @@
    [620]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587864
-     1 string m_Localized = "Oh no, the enemy is moving faster than we thought. We must hurry, the enemy will be here soon."
+     1 string m_Localized = "It's bad. The enemy is moving faster than we expected. They'll be here soon if we don't hurry."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4990,7 +4990,7 @@
    [621]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587865
-     1 string m_Localized = "Perriere! Let's get the hell out of here!"
+     1 string m_Localized = "Lady Perrielle! We must flee, quickly!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -4998,7 +4998,7 @@
    [622]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587866
-     1 string m_Localized = "Mi, mi, everyone, escort the young lady!"
+     1 string m_Localized = "Ev-...Everyone, escort our Lady!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5006,7 +5006,7 @@
    [623]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587867
-     1 string m_Localized = "Yes, we'd better hurry. Gather the remaining soldiers immediately ......"
+     1 string m_Localized = "Yes, we need to hurry. Gather our remaining troops immediately..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5014,7 +5014,7 @@
    [624]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587868
-     1 string m_Localized = "Yumir, gather the rest of your men and head for the east gate and escape from there."
+     1 string m_Localized = "Ymir, gather our remaining troops, head for the east gate, and escape through there."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5022,7 +5022,7 @@
    [625]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587869
-     1 string m_Localized = "What ...... do you mean?"
+     1 string m_Localized = "What... are you implying?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5030,7 +5030,7 @@
    [626]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587870
-     1 string m_Localized = "Oh, you're going with me, aren't you, miss?"
+     1 string m_Localized = "You-... You're going with them, aren't you? My Lady??"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5038,7 +5038,7 @@
    [627]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587871
-     1 string m_Localized = "Oh, no. You will be my decoy to escape."
+     1 string m_Localized = "No, not quite.\nYou will be serving as my decoys to cover my own escape."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5046,7 +5046,7 @@
    [628]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587872
-     1 string m_Localized = "There is an escape route near this mansion. It's for the Grumm family."
+     1 string m_Localized = "There is a secret passage near this manor meant for emergencies. A House Grum secret."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5054,7 +5054,7 @@
    [629]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587873
-     1 string m_Localized = "Let's meet up somewhere. I won't allow you to keep losing like this."
+     1 string m_Localized = "Let's set up a safe meeting place. I will <i>not</i> suffer any more defeats like today."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5062,7 +5062,7 @@
    [630]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587874
-     1 string m_Localized = "You're so ...... prepared."
+     1 string m_Localized = "A secret passage, huh? You're very well prepared."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5070,7 +5070,7 @@
    [631]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587875
-     1 string m_Localized = "Well, then, what about that place over there? I've been there before, the abandoned castle! Where the general was!"
+     1 string m_Localized = "Well, well, how about <i>that</i> place?\nThe abandoned castle we were at the other day, where we met that General what's-his-name!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5078,7 +5078,7 @@
    [632]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587876
-     1 string m_Localized = "Oh, there it is. We'll have to go through the tunnels, but I think we'll have a better chance with our small force."
+     1 string m_Localized = "Oh, that place.\nWe'd have to go through the old mine tunnels, but I think we'll have the advantage over the Imperials with our small force."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5086,7 +5086,7 @@
    [633]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587877
-     1 string m_Localized = "Okay, let's go there."
+     1 string m_Localized = "Very well, let's meet up there."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5094,7 +5094,7 @@
    [634]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587878
-     1 string m_Localized = "If it's available, we'll use it as a stronghold to build an army of resistance. I'm going to give that smirking duke a stroke!"
+     1 string m_Localized = "If it's salvageable, we'll use it as a stronghold to build a resistance army. And then we'll give that a smug Duke a good thrashing!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5110,7 +5110,7 @@
    [636]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587880
-     1 string m_Localized = "Then I will pack up the rest of my troops and head over there. For the lady, Junkers and ......"
+     1 string m_Localized = "In that case, I will gather our remaining troops and head over there.\nAs for our Lady, Janquis, and..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5118,7 +5118,7 @@
    [637]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587881
-     1 string m_Localized = "For the escort, ......<autosubmit=0.5>"
+     1 string m_Localized = "The escort...<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5126,7 +5126,7 @@
    [638]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587882
-     1 string m_Localized = "I'll take that job. I'll take care of that job. I think it's safer to go with the young lady. That's what I believe in."
+     1 string m_Localized = "I'll take that job. I have a feeling that escorting the Lady is the safer of the two jobs, and I'm <i>always</i> looking to survive. That's my personal creed."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5134,7 +5134,7 @@
    [639]
     0 TableEntryData data
      0 SInt64 m_Id = 2855587883
-     1 string m_Localized = "Give it to me, Mio, Gao."
+     1 string m_Localized = "Let me have this one, Mio, Gao."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5142,7 +5142,7 @@
    [640]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782144
-     1 string m_Localized = "Oh, no! That's not fair!"
+     1 string m_Localized = "HUUUH?! That's not fair!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5158,7 +5158,7 @@
    [642]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782146
-     1 string m_Localized = "Hmm, ...... the creed of mercenaries. Then, let's ask."
+     1 string m_Localized = "Hmm... the creed of a mercenary, huh?\nAlright, she's in your care."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5166,7 +5166,7 @@
    [643]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782147
-     1 string m_Localized = "Okay, we'll go ahead then."
+     1 string m_Localized = "Okay, we'll be departing first then."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5174,7 +5174,7 @@
    [644]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782148
-     1 string m_Localized = "Miss, please get out of here safely."
+     1 string m_Localized = "My Lady, please get out of here safely."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5190,7 +5190,7 @@
    [646]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782150
-     1 string m_Localized = "Oh, and Nowa. Come over here for a minute."
+     1 string m_Localized = "Oh, and Nowa. Please, walk with me for a moment."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5198,7 +5198,7 @@
    [647]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782151
-     1 string m_Localized = "Me?"
+     1 string m_Localized = "<i>Me</i>??"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5206,7 +5206,7 @@
    [648]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782152
-     1 string m_Localized = "Nowa, I need you to do something for me."
+     1 string m_Localized = "Nowa, I have a favour to ask of you."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5214,7 +5214,7 @@
    [649]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782153
-     1 string m_Localized = "A favor?"
+     1 string m_Localized = "A favour?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5222,7 +5222,7 @@
    [650]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782154
-     1 string m_Localized = "In case ...... you get it, in case you get it."
+     1 string m_Localized = "For the one in ten thousand... yes, the one in ten thousand possibilities."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5230,7 +5230,7 @@
    [651]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782155
-     1 string m_Localized = "In case I can't join you, I need you to build an army of resistance, Nowa. I want you to."
+     1 string m_Localized = "In that unlikely scenario, where I am unable to join up you, I will need you to raise my resistance army, Nowa.\nI want <i>you</i> to do it."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5238,7 +5238,7 @@
    [652]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782156
-     1 string m_Localized = "You want me to build an army of resistance ......?"
+     1 string m_Localized = "Raise the resistance army?\n<i>ME</i>??"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5246,7 +5246,7 @@
    [653]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782157
-     1 string m_Localized = "Of course, I will raise an army for the ninety-nine thousand out of ten thousand."
+     1 string m_Localized = "Of course, in the other nine thousand, nine hundred, and ninty-nine possible futures, I'll be the one raising the army."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5254,7 +5254,7 @@
    [654]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782158
-     1 string m_Localized = "So, just in case. I'm not sure if I can ask you to do that."
+     1 string m_Localized = "But, for that one in ten thousand. Could I ask this favour of you?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5270,7 +5270,7 @@
    [656]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782160
-     1 string m_Localized = "............, yes, I will."
+     1 string m_Localized = "... Is that so? Me?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5294,7 +5294,7 @@
    [659]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782163
-     1 string m_Localized = "Well, I grew up seeing all kinds of people from a very young age."
+     1 string m_Localized = "You know, I've met with all kinds of interesting people from a very young age."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5302,7 +5302,7 @@
    [660]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782164
-     1 string m_Localized = "There are very few people in this world that I can trust."
+     1 string m_Localized = "In that time, I've learned that there are very few people in this world whom I can trust."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5310,7 +5310,7 @@
    [661]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782165
-     1 string m_Localized = "But I also learned that there are people you can trust. But I also learned that there are people you can trust, even if they are few."
+     1 string m_Localized = "But, I've also learned that there are those whom I <i>can</i> trust. Even if they are few in number."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5318,7 +5318,7 @@
    [662]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782166
-     1 string m_Localized = "I feel that you are the kind of person I can trust with my requests."
+     1 string m_Localized = "I have a feeling that you are one of the few. One whom I can trust with my wishes."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5334,7 +5334,7 @@
    [664]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782168
-     1 string m_Localized = "And you ...... look a little like someone I used to like."
+     1 string m_Localized = "Furthermore, you...\nYou remind me a little of someone I once loved."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5342,7 +5342,7 @@
    [665]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782169
-     1 string m_Localized = "What?"
+     1 string m_Localized = "Huh???"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5350,7 +5350,7 @@
    [666]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782170
-     1 string m_Localized = "Go on. Hurry up and be a decoy for me! That's an order! Run!"
+     1 string m_Localized = "Now, go.\nHurry up and be a good decoy for me!\nThat's an order! Double time!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5358,7 +5358,7 @@
    [667]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782171
-     1 string m_Localized = "Oh, oh, okay. I promise!"
+     1 string m_Localized = "Ye-yes! Understood! I promise!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5366,7 +5366,7 @@
    [668]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782172
-     1 string m_Localized = "I'm asking you, ...... Nowa."
+     1 string m_Localized = "I'm counting on you, Nowa."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5374,7 +5374,7 @@
    [669]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782173
-     1 string m_Localized = "You want to raise an army or ............?"
+     1 string m_Localized = "Raise an army...??"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5382,7 +5382,7 @@
    [670]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782174
-     1 string m_Localized = "I understand I'm asking a lot of you. But ......."
+     1 string m_Localized = "I understand I'm asking a lot of you. But..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5390,7 +5390,7 @@
    [671]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782175
-     1 string m_Localized = "Yes, ......."
+     1 string m_Localized = "Yes..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5398,7 +5398,7 @@
    [672]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782176
-     1 string m_Localized = "I'm too meddlesome, that's what the Lean guys say."
+     1 string m_Localized = "I'm far too meddlesome, that's what Leene used to say to me."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5406,7 +5406,7 @@
    [673]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782177
-     1 string m_Localized = "Hmmm ...... what's that? But then, that's ......."
+     1 string m_Localized = "Hehe, what's that about?\nBut, in that case, will you...?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5414,7 +5414,7 @@
    [674]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782178
-     1 string m_Localized = "Yeah, so. I'll do you this favor ...... I promise."
+     1 string m_Localized = "Yeah, so, I'll do you this favour. I promise."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5422,7 +5422,7 @@
    [675]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782179
-     1 string m_Localized = "It'll only be in case of an emergency, but I'll never forget it."
+     1 string m_Localized = "This is just in case something goes wrong. But either way, I won't forget."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5438,7 +5438,7 @@
    [677]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782181
-     1 string m_Localized = "Hmmm......... that's nice. I can't believe I'm being meddled with."
+     1 string m_Localized = "Hehehe, it feels nice to be meddled with."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5446,7 +5446,7 @@
    [678]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782182
-     1 string m_Localized = "I knew I was right to ask you to help me."
+     1 string m_Localized = "I knew I could trust you to help me with this."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5454,7 +5454,7 @@
    [679]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782183
-     1 string m_Localized = "But are you sure you want me to do it?"
+     1 string m_Localized = "But, are you sure you're okay with <i>me</i> doing this?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5470,7 +5470,7 @@
    [681]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782185
-     1 string m_Localized = "You know, you look a little like someone I used to like at ......."
+     1 string m_Localized = "You kinda... remind me a little of someone I once loved."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5478,7 +5478,7 @@
    [682]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782186
-     1 string m_Localized = "What?"
+     1 string m_Localized = "Huh???"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5486,7 +5486,7 @@
    [683]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782187
-     1 string m_Localized = "Go on. Hurry up and be a decoy for me! That's an order! Run!"
+     1 string m_Localized = "Now, go.\nHurry up and be a good decoy for me!\nThat's an order! Double time!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5494,7 +5494,7 @@
    [684]
     0 TableEntryData data
      0 SInt64 m_Id = 2859782188
-     1 string m_Localized = "Oh, oh, okay."
+     1 string m_Localized = "Ye-yes! Understood!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5502,7 +5502,7 @@
    [685]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976448
-     1 string m_Localized = "I'm counting on you, ...... Nowa."
+     1 string m_Localized = "I'm counting on you, Nowa."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5510,7 +5510,7 @@
    [686]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976449
-     1 string m_Localized = "Oh, Nowa! Oh, Nowa! What was the story?"
+     1 string m_Localized = "Oh, Nowa! You're here, you're here! What did she talk to you about?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5518,7 +5518,7 @@
    [687]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976450
-     1 string m_Localized = "Oh, that's ......."
+     1 string m_Localized = "Oh, it was-"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5526,7 +5526,7 @@
    [688]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976451
-     1 string m_Localized = "You can talk later. Nowa, you guys go ahead and break through to the east gate and open it."
+     1 string m_Localized = "Please save it for later.\nNowa, you and your men will take the lead, break through to the east gate, and get it open."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5534,7 +5534,7 @@
    [689]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976452
-     1 string m_Localized = "I'll follow after I gather my men."
+     1 string m_Localized = "I'll follow soon after, once I've gathered my men."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5542,7 +5542,7 @@
    [690]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976453
-     1 string m_Localized = "Yes, ...... yes!"
+     1 string m_Localized = "Huh? Oh. Yes, sir!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5550,7 +5550,7 @@
    [691]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976454
-     1 string m_Localized = "Okay, hurry up, Nowa!"
+     1 string m_Localized = "All right, let's move, Nowa!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5558,7 +5558,7 @@
    [692]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976455
-     1 string m_Localized = "Hurry, Nowa."
+     1 string m_Localized = "Please hurry, Nowa."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5566,7 +5566,7 @@
    [693]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976456
-     1 string m_Localized = "Nowa, hurry up, Nowa! Yumir said to go to the east gate!"
+     1 string m_Localized = "Wait, wait, not this way! Ymir said to go to the east gate!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5574,7 +5574,7 @@
    [694]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976457
-     1 string m_Localized = "Nowa, don't panic, Nowa. Nowa, don't be hasty, Nowa. We're going to the east gate."
+     1 string m_Localized = "Don't panic, Noah. We're heading to the east gate."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5582,7 +5582,7 @@
    [695]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976458
-     1 string m_Localized = "Nowa, don't panic, Nowa. We're going to the east gate."
+     1 string m_Localized = "We're going to the east gate, Noah."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5590,7 +5590,7 @@
    [696]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976459
-     1 string m_Localized = "No, no - this way is full of enemies! We're going to the east gate!"
+     1 string m_Localized = "No, no! This way is full of enemies! Let's head to the east gate!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5598,7 +5598,7 @@
    [697]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976460
-     1 string m_Localized = "There it is!"
+     1 string m_Localized = "THERE THEY ARE!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5606,7 +5606,7 @@
    [698]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976461
-     1 string m_Localized = "We're almost there!"
+     1 string m_Localized = "We're already this close!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5622,7 +5622,7 @@
    [700]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976463
-     1 string m_Localized = "It looks like we're under control."
+     1 string m_Localized = "Looks like the suppression is progressing."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5630,7 +5630,7 @@
    [701]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976464
-     1 string m_Localized = "General Chapelle, the remnants of the army are gathering and heading for the east gate!"
+     1 string m_Localized = "General Chapell, some stragglers are rallying and heading for the east gate!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5638,7 +5638,7 @@
    [702]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976465
-     1 string m_Localized = "That one was assigned to that little koetling of the Kaesling family, wasn't it?"
+     1 string m_Localized = "That area was assigned to that Kesling boy, wasn't it?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5646,7 +5646,7 @@
    [703]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976466
-     1 string m_Localized = "Yes, and so Lieutenant Say has contacted me to ask you to turn the troops around."
+     1 string m_Localized = "Yes, sir. And Lieutenant Seign has requested that we dispatch more troops."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5654,7 +5654,7 @@
    [704]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976467
-     1 string m_Localized = "Huh. ...... I don't need to send troops."
+     1 string m_Localized = "Hmph... There is no need to send more troops."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5662,7 +5662,7 @@
    [705]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976468
-     1 string m_Localized = "Eh, but Lieutenant Say's unit has only a few soldiers other than the magic tank, so ......"
+     1 string m_Localized = "Huh? But, besides the Rune tank, Lieutenant Seign's unit has few soldiers...!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5670,7 +5670,7 @@
    [706]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976469
-     1 string m_Localized = "I hear that he is a genius of the Kaesling family who is well remembered by the Duke."
+     1 string m_Localized = "I hear that he's a gifted young man of House Kesling, and is well regarded by the Duke."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5678,7 +5678,7 @@
    [707]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976470
-     1 string m_Localized = "I am sure he will not be fooled by an enemy of that caliber. I have no doubt of that."
+     1 string m_Localized = "He shouldn't have any problems dealing with mere stragglers. I have no doubt of that."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5686,7 +5686,7 @@
    [708]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976471
-     1 string m_Localized = "We have to get out of here!"
+     1 string m_Localized = "We have to get through!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5694,7 +5694,7 @@
    [709]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976472
-     1 string m_Localized = "We've got to get out of here!"
+     1 string m_Localized = "WE'LL <i>FORCE</i> OUR WAY THROUGH!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5702,7 +5702,7 @@
    [710]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976473
-     1 string m_Localized = "Oh, my God, these are the guards!"
+     1 string m_Localized = "They're from the Watch!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5718,7 +5718,7 @@
    [712]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976475
-     1 string m_Localized = "Whew, we're almost to the east gate!"
+     1 string m_Localized = "Whew, we're almost at the east gate!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5726,7 +5726,7 @@
    [713]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976476
-     1 string m_Localized = "That's ......."
+     1 string m_Localized = "That's..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5734,7 +5734,7 @@
    [714]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976477
-     1 string m_Localized = "Oh, yeah, no reinforcements. ......"
+     1 string m_Localized = "I see, no reinforcements..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5742,7 +5742,7 @@
    [715]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976478
-     1 string m_Localized = "Oh, no!"
+     1 string m_Localized = "WHAT?! That's awful!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5750,7 +5750,7 @@
    [716]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976479
-     1 string m_Localized = "Oh, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no."
+     1 string m_Localized = "Well, that's just <i>grand</i>."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5758,7 +5758,7 @@
    [717]
     0 TableEntryData data
      0 SInt64 m_Id = 2863976480
-     1 string m_Localized = "Yes, yes, ......, that General Chapelle is ........."
+     1 string m_Localized = "Yes, sir... The thing is, General Chapell..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5766,7 +5766,7 @@
    [718]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170752
-     1 string m_Localized = "Good. I know."
+     1 string m_Localized = "It's fine. I know."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5774,7 +5774,7 @@
    [719]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170753
-     1 string m_Localized = "Paul, move the magic tanks, we'll use them as a barricade."
+     1 string m_Localized = "Pohl, move the Rune tank. We'll use it as part of a barricade."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5782,7 +5782,7 @@
    [720]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170754
-     1 string m_Localized = "Okay, okay."
+     1 string m_Localized = "O-okay."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5790,7 +5790,7 @@
    [721]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170755
-     1 string m_Localized = "Okay, okay. Lt. Say!"
+     1 string m_Localized = "Lieutenant Seign!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5798,7 +5798,7 @@
    [722]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170756
-     1 string m_Localized = "Say ......, is that you?"
+     1 string m_Localized = "Seign, is that really you?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5806,7 +5806,7 @@
    [723]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170757
-     1 string m_Localized = "Nowa. ......"
+     1 string m_Localized = "Nowa..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5830,7 +5830,7 @@
    [726]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170760
-     1 string m_Localized = "You must have seen ...... that this fight isn't the right one."
+     1 string m_Localized = "You <i>must</i> have seen it too...\nThat this was an unjust battle."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5838,7 +5838,7 @@
    [727]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170761
-     1 string m_Localized = "Yes, ...... it is."
+     1 string m_Localized = "Yes, it was."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5846,7 +5846,7 @@
    [728]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170762
-     1 string m_Localized = "But I'm a soldier of the Empire ......."
+     1 string m_Localized = "But, I am a soldier of the Empire..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5854,7 +5854,7 @@
    [729]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170763
-     1 string m_Localized = "I am the heir to the Kaesling family name."
+     1 string m_Localized = "I am the heir of House Kesling."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5862,7 +5862,7 @@
    [730]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170764
-     1 string m_Localized = "Say...... I know what you're trying to do."
+     1 string m_Localized = "Seign, I'm aware of what you're trying to achieve."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5870,7 +5870,7 @@
    [731]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170765
-     1 string m_Localized = "But I've got something I have to do."
+     1 string m_Localized = "But, I've got things I have to do too."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5886,7 +5886,7 @@
    [733]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170767
-     1 string m_Localized = "Lieutenant Sey!"
+     1 string m_Localized = "Lieutenant Seign!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5894,7 +5894,7 @@
    [734]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170768
-     1 string m_Localized = "You're not going to back down, are you?"
+     1 string m_Localized = "You're not going to back down, huh?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5902,7 +5902,7 @@
    [735]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170769
-     1 string m_Localized = "I'm sorry."
+     1 string m_Localized = "Regretfully, no."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5918,7 +5918,7 @@
    [737]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170771
-     1 string m_Localized = "Damn it, ......."
+     1 string m_Localized = "Damn it...!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5926,7 +5926,7 @@
    [738]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170772
-     1 string m_Localized = "I'm sorry, but I'm going to have to take you captive, and the Kaesling family will decide what to do with you afterwards. ......"
+     1 string m_Localized = "I'm sorry, but I'm going to have to take you captive. House Kesling will decide what to do with you later..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5934,7 +5934,7 @@
    [739]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170773
-     1 string m_Localized = "Brother, brother... ！！！！！"
+     1 string m_Localized = "BIG BROOOO！！！"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5942,7 +5942,7 @@
    [740]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170774
-     1 string m_Localized = "Are you all right, brother?"
+     1 string m_Localized = "Are you all right, bro?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5950,7 +5950,7 @@
    [741]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170775
-     1 string m_Localized = "Oh, no."
+     1 string m_Localized = "Not good."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5958,7 +5958,7 @@
    [742]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170776
-     1 string m_Localized = "Are you okay, Nowa?"
+     1 string m_Localized = "Are you okay, Nowa?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5966,7 +5966,7 @@
    [743]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170777
-     1 string m_Localized = "Hey, guys!"
+     1 string m_Localized = "It's... it's everyone!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5982,7 +5982,7 @@
    [745]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170779
-     1 string m_Localized = "Oh, no. ...... we're out of time."
+     1 string m_Localized = "And there it is, time's up."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5990,7 +5990,7 @@
    [746]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170780
-     1 string m_Localized = "I'm here to help you, Nowa's brother! I'm here to help you!"
+     1 string m_Localized = "NOWA, BIG BRO! I'M HERE TO HELP YOU!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -5998,7 +5998,7 @@
    [747]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170781
-     1 string m_Localized = "Damn ......."
+     1 string m_Localized = "Damn it..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6006,7 +6006,7 @@
    [748]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170782
-     1 string m_Localized = "Sorry, Sey. I'm going to have to ask you to let me through."
+     1 string m_Localized = "Sorry, Seign. I'm going through."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6014,7 +6014,7 @@
    [749]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170783
-     1 string m_Localized = "Oh ...... that's your right. You're a winner ......."
+     1 string m_Localized = "Yeah, that is your right, as the victor..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6022,7 +6022,7 @@
    [750]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170784
-     1 string m_Localized = "Will we see you again?"
+     1 string m_Localized = "Will we see each other again?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6030,7 +6030,7 @@
    [751]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170785
-     1 string m_Localized = "I'll move on however I can. If you do too, maybe eventually ......."
+     1 string m_Localized = "I'll keep moving forward, any way I can. If you do the same, the perhaps, one day..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6038,7 +6038,7 @@
    [752]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170786
-     1 string m_Localized = "Why did you stay?"
+     1 string m_Localized = "Why did you stay behind?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6046,7 +6046,7 @@
    [753]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170787
-     1 string m_Localized = "I'm going to thoroughly investigate my employer. There's no such thing as a secret loophole, is there?"
+     1 string m_Localized = "I'm here to thoroughly investigate my employer. There <i>is</i> no 'secret passage', is there?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6054,7 +6054,7 @@
    [754]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170788
-     1 string m_Localized = "If you stay, they'll be less likely to come after them."
+     1 string m_Localized = "If you stay, they'll be less likely to chase after the others."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6062,7 +6062,7 @@
    [755]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170789
-     1 string m_Localized = "Hmmm... ...... why then, even more so?"
+     1 string m_Localized = "Hmmm...\nSo then, all the more... <i>Why</i>?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6070,7 +6070,7 @@
    [756]
     0 TableEntryData data
      0 SInt64 m_Id = 2868170790
-     1 string m_Localized = "Because you never doubted us at all. We have to return the favor."
+     1 string m_Localized = "You never doubted us at all, not even for a moment. We have to repay faith with faith, or else we'd be liars."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6078,7 +6078,7 @@
    [757]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365056
-     1 string m_Localized = "And you look ...... like you don't stand a chance."
+     1 string m_Localized = "And, that look you've got...\nIts not the look of someone whose consigned to her fate."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6086,7 +6086,7 @@
    [758]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365057
-     1 string m_Localized = "Oh, sweetheart. ！！！！"
+     1 string m_Localized = "Oh, My Lady!!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6094,7 +6094,7 @@
    [759]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365058
-     1 string m_Localized = "I'm already here. You're really good with your hands."
+     1 string m_Localized = "He's here already? Well, he's certainly quick when he wants to be."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6102,7 +6102,7 @@
    [760]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365059
-     1 string m_Localized = "It's been a long time, Mademoiselle Perrière."
+     1 string m_Localized = "It's been a while, Miss Perrielle."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6110,7 +6110,7 @@
    [761]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365060
-     1 string m_Localized = "What can I do for you today, Duke?"
+     1 string m_Localized = "Oh, what can I do for you today, Duke?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6118,7 +6118,7 @@
    [762]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365061
-     1 string m_Localized = "You look the same as ever."
+     1 string m_Localized = "You haven't changed at all."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6126,7 +6126,7 @@
    [763]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365062
-     1 string m_Localized = "Well, I thought we could discuss our new relationship."
+     1 string m_Localized = "Well, I'd thought we could discuss our new relationship today."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6134,7 +6134,7 @@
    [764]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365063
-     1 string m_Localized = "If you're asking me to marry you, I'm sorry."
+     1 string m_Localized = "If this is a marriage proposal, then I must apologize."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6142,7 +6142,7 @@
    [765]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365064
-     1 string m_Localized = "I already have a wife."
+     1 string m_Localized = "Heh-heh-heh! I already have a wife."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6150,7 +6150,7 @@
    [766]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365065
-     1 string m_Localized = "Count Grum, if you enter into a new relationship with my empire, I promise to relieve you of your position, your property, and this house."
+     1 string m_Localized = "Countess Grum, you have my word that if you enter into a new relationship with my Empire, then your position, your property, and this manor will all be affirmed."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6158,7 +6158,7 @@
    [767]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365066
-     1 string m_Localized = "Not a bad proposition, is it?"
+     1 string m_Localized = "Not a bad proposition, don't you agree?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6166,7 +6166,7 @@
    [768]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365067
-     1 string m_Localized = "You want me to take the empire ...... under your wing?"
+     1 string m_Localized = "The Empire...\nYou want me to serve under you?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6174,7 +6174,7 @@
    [769]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365068
-     1 string m_Localized = "What about the League of Nations?"
+     1 string m_Localized = "I wonder, what of the other nations in the League?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6182,7 +6182,7 @@
    [770]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365069
-     1 string m_Localized = "I don't need to know what happens to those who disappear, do I?"
+     1 string m_Localized = "You don't <i>need</i> to know fate those who are about to disappear, do you?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6190,7 +6190,7 @@
    [771]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365070
-     1 string m_Localized = "Besides, I would give you a fair assessment of your talents. If you show me your loyalty, I will leave you the lands of the Confederation."
+     1 string m_Localized = "Besides, I will give you the recognition you deserve for your talents. Swear your loyalty to me, and I will entrust all the lands of the League to you."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6198,7 +6198,7 @@
    [772]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365071
-     1 string m_Localized = "Hmm, not a bad offer."
+     1 string m_Localized = "Hmmm, not a bad proposition."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6206,7 +6206,7 @@
    [773]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365072
-     1 string m_Localized = "Well? Are you pleased with it?"
+     1 string m_Localized = "How about it? Does it please you?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6214,7 +6214,7 @@
    [774]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365073
-     1 string m_Localized = "Yes, but ......"
+     1 string m_Localized = "It does, but..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6222,7 +6222,7 @@
    [775]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365074
-     1 string m_Localized = "No!"
+     1 string m_Localized = "No, thank you!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6230,7 +6230,7 @@
    [776]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365075
-     1 string m_Localized = "I'd rather fight as a muddy soldier with a spear than live a life of luxury under you!"
+     1 string m_Localized = "I would rather fight as a soldier in the mud with a spear than live a life of luxury under you!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6238,7 +6238,7 @@
    [777]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365076
-     1 string m_Localized = "You! You, against the Duke!"
+     1 string m_Localized = "BITCH! You are addressing the DUKE!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6246,7 +6246,7 @@
    [778]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365077
-     1 string m_Localized = "Chapelle, good."
+     1 string m_Localized = "Enough, Chapell."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6254,7 +6254,7 @@
    [779]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365078
-     1 string m_Localized = "You don't think I can be trusted, Mistress Perrier?"
+     1 string m_Localized = "Do you find me <i>untrustworthy</i>, Miss Perrielle?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6262,7 +6262,7 @@
    [780]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365079
-     1 string m_Localized = "The emperor of the Gardian Empire is still alive. How can I trust a man who speaks of it as if it were his own?"
+     1 string m_Localized = "The Emperor of the Galdea still yet lives. How can I place trust in a man who speaks of the Empire as if it were already his own?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6270,7 +6270,7 @@
    [781]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365080
-     1 string m_Localized = "I see."
+     1 string m_Localized = "Heh heh, I see."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6278,7 +6278,7 @@
    [782]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365081
-     1 string m_Localized = "Well then, if you'll excuse me. I'll leave you to it. I don't think I have any more business here. I'll leave you to it."
+     1 string m_Localized = "Now then, if you'll excuse me. I don't think there is any point in my remaining here. May I take me leave?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6286,7 +6286,7 @@
    [783]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365082
-     1 string m_Localized = "What nonsense, such .............<autosubmit=0.5>"
+     1 string m_Localized = "How dare you, what nonsense...<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6294,7 +6294,7 @@
    [784]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365083
-     1 string m_Localized = "Hmmm... ......."
+     1 string m_Localized = "Heh-heh..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6302,7 +6302,7 @@
    [785]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365084
-     1 string m_Localized = "Hmmm, you really are an interesting young lady...... no, woman. She would rather sleep in a shabby barracks than in a luxurious bed."
+     1 string m_Localized = "Hah-hah-hah! You truly are an interesting young lady... no, a woman.\nYou'd rather sleep in a shabby barracks than in a luxurious bed."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6310,7 +6310,7 @@
    [786]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365085
-     1 string m_Localized = "Good, escort her politely out of the city gates. Anyone who lays a finger on her will be beheaded."
+     1 string m_Localized = "Very well, kindly escort her to city gates. Anyone who lays a finger on her will be beheaded."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6318,7 +6318,7 @@
    [787]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365086
-     1 string m_Localized = "Good, I don't need help walking on my own two feet."
+     1 string m_Localized = "It's fine. I don't need any assistance to walk with my own two feet."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6326,7 +6326,7 @@
    [788]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365087
-     1 string m_Localized = "Oh, my lady!<autosubmit=0.5>"
+     1 string m_Localized = "Yes, My Lady!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6334,7 +6334,7 @@
    [789]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365088
-     1 string m_Localized = "But, Duke!<autosubmit=0.5>"
+     1 string m_Localized = "But, Duke-!<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6342,7 +6342,7 @@
    [790]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365089
-     1 string m_Localized = "No, it's just a woman and an old man, what can they do?"
+     1 string m_Localized = "Its fine. It's just a woman and an old man, what could they possibly do?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6350,7 +6350,7 @@
    [791]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365090
-     1 string m_Localized = "I promise you, that woman will make you look like an old man."
+     1 string m_Localized = "I swear to you, <i>this</i> 'woman' will draw a dark cloud over that smug expression of your's."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6358,7 +6358,7 @@
    [792]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365091
-     1 string m_Localized = "Well, good day to you."
+     1 string m_Localized = "Until then, I bid you farewell."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6366,7 +6366,7 @@
    [793]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365092
-     1 string m_Localized = "Oh, hello! Hello! I work here as a warehouse keeper!"
+     1 string m_Localized = "Oh, greetings, big brother! I work as a warehouse keeper here!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6374,7 +6374,7 @@
    [794]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365093
-     1 string m_Localized = "I'll take good care of your belongings here, so please call me anytime!"
+     1 string m_Localized = "I'll take good care of your belongings here, so please call on me anytime!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6382,7 +6382,7 @@
    [795]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365094
-     1 string m_Localized = "Oh, welcome. Oh, hello, I'm Cassandra, I work here at the inn. I'm Cassandra, and I'm an innkeeper here."
+     1 string m_Localized = "Oh, welcome. Hehe.\nI am Cassandra, I'm the innkeeper here."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6390,7 +6390,7 @@
    [796]
     0 TableEntryData data
      0 SInt64 m_Id = 2872365095
-     1 string m_Localized = "Whenever you need a little healing, come back to me."
+     1 string m_Localized = "Return to me whenever you need a little healing."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6406,7 +6406,7 @@
    [798]
     0 TableEntryData data
      0 SInt64 m_Id = 55725795339853824
-     1 string m_Localized = "Not this way. ......."
+     1 string m_Localized = "Not this way..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)

--- a/text_DeepL/MainScenario_02_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--5619663750649154153.txt
+++ b/text_DeepL/MainScenario_02_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--5619663750649154153.txt
@@ -206,7 +206,7 @@
    [23]
     0 TableEntryData data
      0 SInt64 m_Id = 2796867606
-     1 string m_Localized = "Acting platoon leader.\nI've already discussed this with Garr, but I have a new mission for you."
+     1 string m_Localized = "Acting Squad leader.\nI've already discussed this with Garr, but I have a new mission for you."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2278,7 +2278,7 @@
    [282]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033447
-     1 string m_Localized = "What? What's that?"
+     1 string m_Localized = "Hmmm? What's that?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2286,7 +2286,7 @@
    [283]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033448
-     1 string m_Localized = "Gao and Nowa, in the right place."
+     1 string m_Localized = "Gao and Nowa, its good to see you here."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2294,7 +2294,7 @@
    [284]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033449
-     1 string m_Localized = "Miss Mio! You're back!"
+     1 string m_Localized = "Sis Mio! You're back!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2302,7 +2302,7 @@
    [285]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033450
-     1 string m_Localized = "I was just on my way to let you know. I was just on my way to let you guys know that."
+     1 string m_Localized = "All members of the Eltisweiss Watch have been ordered to return immediately. I was on my way to inform you."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2310,7 +2310,7 @@
    [286]
     0 TableEntryData data
      0 SInt64 m_Id = 2822033451
-     1 string m_Localized = "Well, I hear this is going to be a real mess."
+     1 string m_Localized = "Ohhh? This sounds like its going to be a serious problem."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2326,7 +2326,7 @@
    [288]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227713
-     1 string m_Localized = "I'm coming back."
+     1 string m_Localized = "Let's return."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2334,7 +2334,7 @@
    [289]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227714
-     1 string m_Localized = "Hmm, looks like that hooded guy is the same guy I met. I'm going to go back."
+     1 string m_Localized = "Hmm, that guy in the hood seems to be the same guy I ran into."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2350,7 +2350,7 @@
    [291]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227716
-     1 string m_Localized = "I don't know, I thought it was funny that he went to all the trouble of attacking me so openly. ......"
+     1 string m_Localized = "Who knows.\nBut I thought it strange that he was so brazen as to attack me out in the open..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2358,7 +2358,7 @@
    [292]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227717
-     1 string m_Localized = "I guess he's doing the Duke of Aldrick's bidding. You probably wouldn't find a shred of evidence of that if you caught him and checked him out."
+     1 string m_Localized = "I'd guess that he was doing Duke Aldric's bidding.\nYou probably wouldn't find a shred of evidence of that even if you'd caught him, though."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2366,7 +2366,7 @@
    [293]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227718
-     1 string m_Localized = "Provocation ......? He seemed to know we were the Guard."
+     1 string m_Localized = "A provocateur, huh? He seemed to know we were of the Watch."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2374,7 +2374,7 @@
    [294]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227719
-     1 string m_Localized = "I'm sure they're just trying to create an excuse for an invasion."
+     1 string m_Localized = "I'm sure they were just trying to create a pretext for an invasion."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2382,7 +2382,7 @@
    [295]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227720
-     1 string m_Localized = "What? What? What?"
+     1 string m_Localized = "Huh? In-Invasion from where?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2390,7 +2390,7 @@
    [296]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227721
-     1 string m_Localized = "The Empire. They're using the fact that members of the Guard are trolling the Imperial border area as a pretext."
+     1 string m_Localized = "The Empire. Their pretext is that members of the Watch are rampaging across the Imperial side of the border."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2398,7 +2398,7 @@
    [297]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227722
-     1 string m_Localized = "What the hell is that? They attacked us!"
+     1 string m_Localized = "What the hell is up with that?\n<i>They</i> attacked <i>us</i>!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2406,7 +2406,7 @@
    [298]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227723
-     1 string m_Localized = "Sometimes the truth of a matter is useless, especially in a place of war. Especially in a place of war."
+     1 string m_Localized = "Sometimes the truth doesn't matter all that much, especially in times of war."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2414,7 +2414,7 @@
    [299]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227724
-     1 string m_Localized = "The Reich is ......"
+     1 string m_Localized = "The Empire is..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2422,7 +2422,7 @@
    [300]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227725
-     1 string m_Localized = "I sent Junkers to Euclis to ask for reinforcements, but I don't know if he'll make it in time.<autosubmit=0.5>"
+     1 string m_Localized = "I've sent Janquis to Euchrisse to request reinforcements, but I don't know if he'll make it in time.<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2430,7 +2430,7 @@
    [301]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227726
-     1 string m_Localized = "Mr. Perrière! I've just been informed that the village of Wolm has been taken over by someone!"
+     1 string m_Localized = "Lady Perrielle! We've just received word that an unknown force has occupied the village of Werne!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2438,7 +2438,7 @@
    [302]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227727
-     1 string m_Localized = "Hmmm..."
+     1 string m_Localized = "Hmmmmmm."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2446,7 +2446,7 @@
    [303]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227728
-     1 string m_Localized = "The duke is quick with the ladies, isn't he?"
+     1 string m_Localized = "The Duke is quick to seize the ladies, isn't he?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2454,7 +2454,7 @@
    [304]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227729
-     1 string m_Localized = "I knew it! I hate him!"
+     1 string m_Localized = "I knew it, I hate him!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2462,7 +2462,7 @@
    [305]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227730
-     1 string m_Localized = "I have already made preparations for defense, as you instructed."
+     1 string m_Localized = "I have already begun making preparations for defense, as you instructed."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2470,7 +2470,7 @@
    [306]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227731
-     1 string m_Localized = "Whether we fight or negotiate, we need to know how serious they are. Send a reconnaissance team to the village of Wolm."
+     1 string m_Localized = "Regardless of whether we fight or negotiate, we need to figure out how serious they are about this.\nPlease send a reconnaissance team to the Werne Village."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2478,7 +2478,7 @@
    [307]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227732
-     1 string m_Localized = "Then go to ......."
+     1 string m_Localized = "In that case..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2502,7 +2502,7 @@
    [310]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227735
-     1 string m_Localized = "Let me go. I want to see for myself what is going on."
+     1 string m_Localized = "Let me go. I want to see with my own eyes what's going on."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2510,7 +2510,7 @@
    [311]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227736
-     1 string m_Localized = "............This will be an important mission, how about it, Mr. Perrière?"
+     1 string m_Localized = "This is a rather important mission.\nWhat say you, Lady Perrille?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2518,7 +2518,7 @@
    [312]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227737
-     1 string m_Localized = "............Good. Let him go, after what happened in his home village."
+     1 string m_Localized = "Very well, let him go.\nHe deserves this, considering what happened in his home village."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2526,7 +2526,7 @@
    [313]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227738
-     1 string m_Localized = "Understood. Then, please reconnoiter, Acting Platoon Leader."
+     1 string m_Localized = "Understood.\nThen, please conduct the reconnaissance, Acting Squad Leader."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2534,7 +2534,7 @@
    [314]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227739
-     1 string m_Localized = "I need you to check on the size of the force occupying the village of Wollum."
+     1 string m_Localized = "You are to confirm on the size of the force occupying Werne Village."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2542,7 +2542,7 @@
    [315]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227740
-     1 string m_Localized = "Oh, I understand."
+     1 string m_Localized = "Yes, I understand."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2550,7 +2550,7 @@
    [316]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227741
-     1 string m_Localized = "I've got a history with them. I'll lend a hand if you need it."
+     1 string m_Localized = "I've got a score to settle with them. I'll lend a hand, if you need it."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2558,7 +2558,7 @@
    [317]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227742
-     1 string m_Localized = "Then select the members: ......"
+     1 string m_Localized = "Now, select your party members..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2574,7 +2574,7 @@
    [319]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227744
-     1 string m_Localized = "Yeah, ......, but the mission is just a reconnaissance. You know what you're doing, Nowa."
+     1 string m_Localized = "Yeah, but this mission is <i>reconnaissance only</i>. Understood, Nowa?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2582,7 +2582,7 @@
    [320]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227745
-     1 string m_Localized = "I know what I'm doing."
+     1 string m_Localized = "I understand."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2590,7 +2590,7 @@
    [321]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227746
-     1 string m_Localized = "He joined the ...... security team six months ago, right?"
+     1 string m_Localized = "He... is the kid who joined the Watch six months ago, right?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2606,7 +2606,7 @@
    [323]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227748
-     1 string m_Localized = "Yeah, but he's ...... promising."
+     1 string m_Localized = "But he's promising."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2614,7 +2614,7 @@
    [324]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227749
-     1 string m_Localized = "I guess so."
+     1 string m_Localized = "It would seem so."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2630,7 +2630,7 @@
    [326]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227751
-     1 string m_Localized = "We'll be selecting members as soon as possible."
+     1 string m_Localized = "We'll be selecting the members as soon as possible."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2638,7 +2638,7 @@
    [327]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227752
-     1 string m_Localized = "Wait a minute ......, let him go."
+     1 string m_Localized = "Hold a moment...\nLet <i>him</i> go."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2646,7 +2646,7 @@
    [328]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227753
-     1 string m_Localized = "What?"
+     1 string m_Localized = "?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2662,7 +2662,7 @@
    [330]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227755
-     1 string m_Localized = "I'm sure I saw you at Ernside, I'm counting on you."
+     1 string m_Localized = "I'm sure saw you at Arenside. I'll be expecting results again."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2670,7 +2670,7 @@
    [331]
     0 TableEntryData data
      0 SInt64 m_Id = 2826227756
-     1 string m_Localized = "Okay, I will. Then, please reconnoiter, Acting Platoon Leader."
+     1 string m_Localized = "Understood.\nThen, please conduct the reconnaissance, Acting Squad Leader."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2678,7 +2678,7 @@
    [332]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422016
-     1 string m_Localized = "I need to confirm the size of the force that's occupying the village of Wolm."
+     1 string m_Localized = "You are to confirm on the size of the force occupying Werne Village."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2686,7 +2686,7 @@
    [333]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422017
-     1 string m_Localized = "......, yeah, I got it."
+     1 string m_Localized = "... Yeah, I understand."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2694,7 +2694,7 @@
    [334]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422018
-     1 string m_Localized = "What? What's the reason you don't want to go? That lieutenant?"
+     1 string m_Localized = "What? Is there a reason you don't want to go?\nIs it that lieutenant?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2710,7 +2710,7 @@
    [336]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422020
-     1 string m_Localized = "No, it's not that. I have a history with him. I'll lend a hand if you need it."
+     1 string m_Localized = "I've got a score to settle with them. I'll lend a hand, if you need it."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2718,7 +2718,7 @@
    [337]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422021
-     1 string m_Localized = "Well, let's select the members: ......"
+     1 string m_Localized = "Now, select your party members..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2734,7 +2734,7 @@
    [339]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422023
-     1 string m_Localized = "Yeah, ......, but the mission is just a reconnaissance. You know what you're doing, Nowa."
+     1 string m_Localized = "Yeah, but this mission is <i>reconnaissance only</i>. Understood, Nowa?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2742,7 +2742,7 @@
    [340]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422024
-     1 string m_Localized = "I know what I'm doing."
+     1 string m_Localized = "I understand."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2750,7 +2750,7 @@
    [341]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422025
-     1 string m_Localized = "Hey, Yumir. What do you think of him?"
+     1 string m_Localized = "Hey, Ymir. What do you think of him?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2758,7 +2758,7 @@
    [342]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422026
-     1 string m_Localized = "I agree with you, miss."
+     1 string m_Localized = "I agree with you, my Lady."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2766,7 +2766,7 @@
    [343]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422027
-     1 string m_Localized = "What do you mean?"
+     1 string m_Localized = "Which means?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2774,7 +2774,7 @@
    [344]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422028
-     1 string m_Localized = "He's very promising."
+     1 string m_Localized = "He's promising."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2782,7 +2782,7 @@
    [345]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422029
-     1 string m_Localized = "Well, when we're ready, we'll head straight for the village of Wolm."
+     1 string m_Localized = "When we're ready, we'll be heading straight for Werne Village."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2790,7 +2790,7 @@
    [346]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422030
-     1 string m_Localized = "Wolm's village is west? Northwest? Was it?"
+     1 string m_Localized = "Werne Village is West? Or was it Northwest?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2798,7 +2798,7 @@
    [347]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422031
-     1 string m_Localized = "If it's the village of Wolm, go west from here along the river, past the bridge, and you'll find yourself in the north direction."
+     1 string m_Localized = "To get to Werne Village, go west from here along the river and go over the bridge. And then you'll see it to the north."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2806,7 +2806,7 @@
    [348]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422032
-     1 string m_Localized = "If it's the village of Wolm, go east, around the lake, through to the north, and then head west."
+     1 string m_Localized = "To get to Werne Village, go out to the east, circle the north around the lake, and then head west. You'll see it."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2814,7 +2814,7 @@
    [349]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422033
-     1 string m_Localized = "It's already in the hands of the enemy ...... deftly."
+     1 string m_Localized = "It's already under full enemy control...\nVery efficient."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2822,7 +2822,7 @@
    [350]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422034
-     1 string m_Localized = "So? So what? What am I scouting for?"
+     1 string m_Localized = "So, so, what are we scouting for?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2830,7 +2830,7 @@
    [351]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422035
-     1 string m_Localized = "We could listen to the soldiers' gossip, check the amount of weapons and food they have, or check the tents in the back."
+     1 string m_Localized = "Could try to listen in on the soldiers' gossiping. Or check how much weapons and provisions they have. Or check the tents at the back."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2846,7 +2846,7 @@
    [353]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422037
-     1 string m_Localized = "Hey, what the fuck are you doing?"
+     1 string m_Localized = "Hey! What the hell are you doing?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2854,7 +2854,7 @@
    [354]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422038
-     1 string m_Localized = "Oh no, we've got to get out of here!"
+     1 string m_Localized = "Not good! Run!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2862,7 +2862,7 @@
    [355]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422039
-     1 string m_Localized = "You're not from the village!"
+     1 string m_Localized = "What the-\nYou're not from the village!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2870,7 +2870,7 @@
    [356]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422040
-     1 string m_Localized = "You're not from the village!"
+     1 string m_Localized = "There's a suspicious guy!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2878,7 +2878,7 @@
    [357]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422041
-     1 string m_Localized = "Shit!"
+     1 string m_Localized = "Damn it!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2886,7 +2886,7 @@
    [358]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422042
-     1 string m_Localized = "No, no, no, no!"
+     1 string m_Localized = "L-LOOK OUT!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2894,7 +2894,7 @@
    [359]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422043
-     1 string m_Localized = "Oh, shit!"
+     1 string m_Localized = "We blundered!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2902,7 +2902,7 @@
    [360]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422044
-     1 string m_Localized = "Oh, no! - Oh, no!"
+     1 string m_Localized = "Retreat!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2910,7 +2910,7 @@
    [361]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422045
-     1 string m_Localized = "Hm! Quietly ......"
+     1 string m_Localized = "Mmh! Quiet..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2918,7 +2918,7 @@
    [362]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422046
-     1 string m_Localized = "What's up with these Coalition guys, they're making such a big deal out of this?"
+     1 string m_Localized = "What's up with those League guys? They've been causing so much trouble lately."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2926,7 +2926,7 @@
    [363]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422047
-     1 string m_Localized = "Six months ago, they were talking about friendship and joint operations."
+     1 string m_Localized = "They were talking about friendly relations and joint operations just six months ago."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2934,7 +2934,7 @@
    [364]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422048
-     1 string m_Localized = "Rumor has it that they're trying to drive out the people who live around them so they can keep the remains of the lens they found in the operation to themselves."
+     1 string m_Localized = "Rumor has it that they're trying to drive out everyone who lives around them so they can keep the Runebarrows they'd found in the joint op to themselves."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2942,7 +2942,7 @@
    [365]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422049
-     1 string m_Localized = "They're greedy people."
+     1 string m_Localized = "What a greedy bunch."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2950,7 +2950,7 @@
    [366]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422050
-     1 string m_Localized = "Well, they said that as soon as the guards hand over the culprits, we can go back to our country."
+     1 string m_Localized = "Well, we'll be able to go home as soon as their 'Watch' hands over the culprits."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2958,7 +2958,7 @@
    [367]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422051
-     1 string m_Localized = "What the hell is that? What the hell is that? You can go to ......."
+     1 string m_Localized = "What the hell is that? Its all hogwash!\nWhy I oughta..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2966,7 +2966,7 @@
    [368]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422052
-     1 string m_Localized = "Hey, don't do that. You don't want to get caught."
+     1 string m_Localized = "Hey, stop it. You'll get caught."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2974,7 +2974,7 @@
    [369]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422053
-     1 string m_Localized = "Is this ......?"
+     1 string m_Localized = "Is this...?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2982,7 +2982,7 @@
    [370]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422054
-     1 string m_Localized = "Hmm? What's all this?"
+     1 string m_Localized = "Hmmm? What's this? So much stuff."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -2990,7 +2990,7 @@
    [371]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422055
-     1 string m_Localized = "There's food, weapons, and ...... about a whole army of this stuff. They seem to be serious. ......"
+     1 string m_Localized = "Provisions... weapons... enough for a whole legion.\nThey seem to be serious about this."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3006,7 +3006,7 @@
    [373]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422057
-     1 string m_Localized = "Really, there's going to be a war ......?"
+     1 string m_Localized = "Is there really going to be a war...?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3014,7 +3014,7 @@
    [374]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422058
-     1 string m_Localized = "I don't think Mistress Perrière would like that, but we're ...... just doing our duty."
+     1 string m_Localized = "I don't think Lady Perrielle wants that, but we've got a job to do."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3022,7 +3022,7 @@
    [375]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422059
-     1 string m_Localized = "We're going to war ...... with the Empire."
+     1 string m_Localized = "A war, with the Empire...!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3030,7 +3030,7 @@
    [376]
     0 TableEntryData data
      0 SInt64 m_Id = 2830422060
-     1 string m_Localized = "Well, what's next ...... that big tent?"
+     1 string m_Localized = "And now, next is... that big tent?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3038,7 +3038,7 @@
    [377]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616320
-     1 string m_Localized = "Oh, that!"
+     1 string m_Localized = "Hey, look!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3054,7 +3054,7 @@
    [379]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616322
-     1 string m_Localized = "Yes, everything's in place."
+     1 string m_Localized = "Sir, everything is in place."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3062,7 +3062,7 @@
    [380]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616323
-     1 string m_Localized = "Yes, everything is in order."
+     1 string m_Localized = "Heh heh, an insignificant nation such as this. There's no need to bother the Duke with such trivialities."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3070,7 +3070,7 @@
    [381]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616324
-     1 string m_Localized = "Well, I'll let you feed on my fame."
+     1 string m_Localized = "Well, they can be fuel for my glory at least."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3078,7 +3078,7 @@
    [382]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616325
-     1 string m_Localized = "That's the general of this army?"
+     1 string m_Localized = "That's this army's general? Although I'm sure there's someone else above him in the chain."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3086,7 +3086,7 @@
    [383]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616326
-     1 string m_Localized = "That's the general of the army. You'd better not get too close."
+     1 string m_Localized = "Security is tight there. We'd better not get too close."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3094,7 +3094,7 @@
    [384]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616327
-     1 string m_Localized = "Hey, hey, can we just take a look at that tent over there?"
+     1 string m_Localized = "Hey, hey, think it'd be okay if we took a look at that enclosure over there?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3102,7 +3102,7 @@
    [385]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616328
-     1 string m_Localized = "Wait!"
+     1 string m_Localized = "Stop!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3110,7 +3110,7 @@
    [386]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616329
-     1 string m_Localized = "Wait! The guards have left their posts?"
+     1 string m_Localized = "Hmm? The lookout has abandoned his post?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3118,7 +3118,7 @@
    [387]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616330
-     1 string m_Localized = "He's slack-jawed, and I'll give him a good beating when he comes back."
+     1 string m_Localized = "That damned slacker. I'm gonna let him have it when he gets back."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3126,7 +3126,7 @@
    [388]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616331
-     1 string m_Localized = "Oh, no, we're in trouble!"
+     1 string m_Localized = "Uwah! We're in a tight spot!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3134,7 +3134,7 @@
    [389]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616332
-     1 string m_Localized = "I can't get out."
+     1 string m_Localized = "Nngh, we can't get out."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3158,7 +3158,7 @@
    [392]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616335
-     1 string m_Localized = "Well, my dear, how are you feeling tonight?"
+     1 string m_Localized = "Well, sweetheart, are you in a good mood tonight?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3166,7 +3166,7 @@
    [393]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616336
-     1 string m_Localized = "Good girl, good girl, good girl, my beloved Sylvie's heart, the face-to-face magic lens furnace produces 500 PS of pressure."
+     1 string m_Localized = "Good girl, good girl, yup yup!\nMy beloved Sylvie's heart, the birunic lens reactor, can produce 500 PS of pressure."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3174,7 +3174,7 @@
    [394]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616337
-     1 string m_Localized = "Soon, we'll be unveiling it. We'll have to make sure she's well dressed ......."
+     1 string m_Localized = "We'll be unveiling you soon. We'll have to make sure you're well-dressed..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3182,7 +3182,7 @@
    [395]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616338
-     1 string m_Localized = "Yeah, yeah, good girl. Sylvie, you're a great girl. ......"
+     1 string m_Localized = "Yeah, yeah, good girl, Sylvie. You're the best girl ever..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3190,7 +3190,7 @@
    [396]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616339
-     1 string m_Localized = "Wow, what's this: ......"
+     1 string m_Localized = "Wow, what <i>is</i> this??"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3198,7 +3198,7 @@
    [397]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616340
-     1 string m_Localized = "Wow, da, da, who? Who? Did you, did you hear me? No way, did you hear me?"
+     1 string m_Localized = "WAAH! Wh-w-wh-who? Who?\nDid-did you hear me?\nNo way, you heard me?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3206,7 +3206,7 @@
    [398]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616341
-     1 string m_Localized = "Yeah, yeah? What? What are you talking about?"
+     1 string m_Localized = "Huh? Ye-yeah?\nWhat were you talking about?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3214,7 +3214,7 @@
    [399]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616342
-     1 string m_Localized = "Because, she's ......, no, I was talking to this machine ......, no, it looks like I'm talking to it, but I was just checking the checkrisk... ..."
+     1 string m_Localized = "That's because, she's-\nNo, I was talking to this machine-\nNo, it <i>looks</i> like I was talking to it, but I was just running the checklist..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3222,7 +3222,7 @@
    [400]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616343
-     1 string m_Localized = "Hmm?"
+     1 string m_Localized = "Mmmmh?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3230,7 +3230,7 @@
    [401]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616344
-     1 string m_Localized = "I mean, you guys don't look familiar. I guess you're not from the military ......."
+     1 string m_Localized = "Say, I don't recognise you guys. I guess that means you're not part of the army..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3238,7 +3238,7 @@
    [402]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616345
-     1 string m_Localized = "Huh, that's good."
+     1 string m_Localized = "Phew, thank goodness."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3246,7 +3246,7 @@
    [403]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616346
-     1 string m_Localized = "You almost made me look like an idiot again."
+     1 string m_Localized = "I almost made a fool of myself again."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3254,7 +3254,7 @@
    [404]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616347
-     1 string m_Localized = "You're not military ......?"
+     1 string m_Localized = "You're... not with the army?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3262,7 +3262,7 @@
    [405]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616348
-     1 string m_Localized = "Uh, I'm more of an engineer."
+     1 string m_Localized = "Uhh, I'm more of an engineer."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3270,7 +3270,7 @@
    [406]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616349
-     1 string m_Localized = "Duke Aldrick has changed the magic lens from a magic ...... limited to a limited number of people who can use it, or an unstable one whose effects change depending on who uses it."
+     1 string m_Localized = "Duke Aldric seeks to advance rune lenses from being limited to a small number of people who can wield them. Or from having unstable effects that change depending on who's wielding them."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3286,7 +3286,7 @@
    [408]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616351
-     1 string m_Localized = "You mean, not witchcraft, but technology?"
+     1 string m_Localized = "You mean, not as magic, but as technology?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3294,7 +3294,7 @@
    [409]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616352
-     1 string m_Localized = "Yes, this Sylvie ...... Oh, no, this magic tank is part of that research."
+     1 string m_Localized = "Yes, Sylvie here... No, this Rune tank is part of that research."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3302,7 +3302,7 @@
    [410]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616353
-     1 string m_Localized = "I originally built it with the help of the Kaesling family, but it caught the Duke's eye."
+     1 string m_Localized = "I originally started working on it with backing from House Kesling, but it caught the Duke's eye."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3310,7 +3310,7 @@
    [411]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616354
-     1 string m_Localized = "The Kaesling family?"
+     1 string m_Localized = "House Kesling?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3318,7 +3318,7 @@
    [412]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616355
-     1 string m_Localized = "Oh, they're my friends, my childhood friends."
+     1 string m_Localized = "Yeah, my childhood friend is from that house."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3326,7 +3326,7 @@
    [413]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616356
-     1 string m_Localized = "Well, they're the son of a nobleman, but ...... I consider them friends."
+     1 string m_Localized = "Well, he may be the son of a nobleman...\nBut I still consider him a friend."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3334,7 +3334,7 @@
    [414]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616357
-     1 string m_Localized = "Well, he's the son of a noble family, but he's not a bad guy. He's not a bad guy. He treats me the same way."
+     1 string m_Localized = "He can be a bit cold at times, but he's not a bad guy. He doesn't treat me any different just because I'm not a noble."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3342,7 +3342,7 @@
    [415]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616358
-     1 string m_Localized = "You mean ...... Sey?"
+     1 string m_Localized = "Might that person be... Seign?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3350,7 +3350,7 @@
    [416]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616359
-     1 string m_Localized = "What? You know about Sei? Are you a friend of Sei's by any chance?"
+     1 string m_Localized = "Huh? You know him? Are you a friend of his, by any chance?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3358,7 +3358,7 @@
    [417]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616360
-     1 string m_Localized = "Well, he told me that he made a friend while he was searching for the ruins in the coalition."
+     1 string m_Localized = "Come to think of it, he told me that he'd made a friend during the joint op to explore the Runebarrows with the League."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3366,7 +3366,7 @@
    [418]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616361
-     1 string m_Localized = "I thought it was unusual for Say to make friends that easily, but that's what you ...... are.<autosubmit=0.5>"
+     1 string m_Localized = "I thought it was unusual for Seign to make friends so easily, but if that was you-<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3374,7 +3374,7 @@
    [419]
     0 TableEntryData data
      0 SInt64 m_Id = 2834616362
-     1 string m_Localized = "Paul, is it this way?"
+     1 string m_Localized = "Pohl? Are you out here?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3382,7 +3382,7 @@
    [420]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810624
-     1 string m_Localized = "!!!!!!!"
+     1 string m_Localized = "!!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3390,7 +3390,7 @@
    [421]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810625
-     1 string m_Localized = "Magic tank activated this time ......<autosubmit=0.5>"
+     1 string m_Localized = "I hope the Rune tank actually started this ti-<autosubmit=0.5>"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3398,7 +3398,7 @@
    [422]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810626
-     1 string m_Localized = "Oh, you guys!"
+     1 string m_Localized = "Aaah! You are...!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3406,7 +3406,7 @@
    [423]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810627
-     1 string m_Localized = "Who are you?"
+     1 string m_Localized = "Who's there?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3414,7 +3414,7 @@
    [424]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810628
-     1 string m_Localized = "Who are you?"
+     1 string m_Localized = "You?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3422,7 +3422,7 @@
    [425]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810629
-     1 string m_Localized = "What? Mr. Hildy!"
+     1 string m_Localized = "Huh? Miss Hildi?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3430,7 +3430,7 @@
    [426]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810630
-     1 string m_Localized = "!!!!"
+     1 string m_Localized = "!!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3438,7 +3438,7 @@
    [427]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810631
-     1 string m_Localized = "Paul! Whistle!"
+     1 string m_Localized = "Pohl! Sound the alarm!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3446,7 +3446,7 @@
    [428]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810632
-     1 string m_Localized = "Uh, yes!"
+     1 string m_Localized = "Huh? Y-YES MA'AM!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3454,7 +3454,7 @@
    [429]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810633
-     1 string m_Localized = "Oh, no!"
+     1 string m_Localized = "Shit!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3462,7 +3462,7 @@
    [430]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810634
-     1 string m_Localized = "There's an intruder! Get him!"
+     1 string m_Localized = "Intruders! Seize them!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3470,7 +3470,7 @@
    [431]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810635
-     1 string m_Localized = "Oh, no!"
+     1 string m_Localized = "Wha-? Really?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3478,7 +3478,7 @@
    [432]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810636
-     1 string m_Localized = "We're retreating! Nowa!"
+     1 string m_Localized = "WE'RE LEAVING, NOWA!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3486,7 +3486,7 @@
    [433]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810637
-     1 string m_Localized = "Nowa!"
+     1 string m_Localized = "Damn it!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3494,7 +3494,7 @@
    [434]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810638
-     1 string m_Localized = "Nowa! What? Huh? Was that Mr. Hildy?"
+     1 string m_Localized = "Huh? Wha-? HUH?! Were those...??\nMiss Hildi?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3510,7 +3510,7 @@
    [436]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810640
-     1 string m_Localized = "It's the enemy."
+     1 string m_Localized = "They were enemies."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3518,7 +3518,7 @@
    [437]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810641
-     1 string m_Localized = "Mr. Hildy. ...... Oh no."
+     1 string m_Localized = "Miss Hildi... How could you..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3526,7 +3526,7 @@
    [438]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810642
-     1 string m_Localized = "Hurry up!"
+     1 string m_Localized = "Let's move!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3542,7 +3542,7 @@
    [440]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810644
-     1 string m_Localized = "There he is!"
+     1 string m_Localized = "THERE THEY ARE!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3550,7 +3550,7 @@
    [441]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810645
-     1 string m_Localized = "I'm here, I'm here!"
+     1 string m_Localized = "Here they come!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3558,7 +3558,7 @@
    [442]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810646
-     1 string m_Localized = "Oh, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no."
+     1 string m_Localized = "This is bad. We have to hurry."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3566,7 +3566,7 @@
    [443]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810647
-     1 string m_Localized = "You're the intruders!"
+     1 string m_Localized = "So you're the intruders?!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3574,7 +3574,7 @@
    [444]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810648
-     1 string m_Localized = "No, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no. Help!"
+     1 string m_Localized = "Wait you got it wrong...!\nHELP ME!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3582,7 +3582,7 @@
    [445]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810649
-     1 string m_Localized = "Oh, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no!"
+     1 string m_Localized = "Aaah, not good! Not good!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3590,7 +3590,7 @@
    [446]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810650
-     1 string m_Localized = "I guess we'll have to break through there to get out."
+     1 string m_Localized = "Looks like we'll have to smash through them to get out."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3598,7 +3598,7 @@
    [447]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810651
-     1 string m_Localized = "I'm not going to let you get away! The coalition!!!!!!!!!!!!!!!!!!!!!!!!!!"
+     1 string m_Localized = "You're not getting away! League-!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3606,7 +3606,7 @@
    [448]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810652
-     1 string m_Localized = "We've got to beat them off!"
+     1 string m_Localized = "Strike them down!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3614,7 +3614,7 @@
    [449]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810653
-     1 string m_Localized = "If they're coming, they're coming!"
+     1 string m_Localized = "If you want some, then come GET SOME!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3622,7 +3622,7 @@
    [450]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810654
-     1 string m_Localized = "Damn it, damn it! You've been tearing up our country. ......"
+     1 string m_Localized = "D-Damn you! You've been rampaging through our lands..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3630,7 +3630,7 @@
    [451]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810655
-     1 string m_Localized = "That's ............."
+     1 string m_Localized = "That's not..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3638,7 +3638,7 @@
    [452]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810656
-     1 string m_Localized = "Sorry ......, now there's no explanation or excuse. It's inexcusable."
+     1 string m_Localized = "Sorry, for now there's no explanation nor justification.\nIt <i>is</i> outrageous though."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3646,7 +3646,7 @@
    [453]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810657
-     1 string m_Localized = "Hurry up!"
+     1 string m_Localized = "LET'S MOVE!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3654,7 +3654,7 @@
    [454]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810658
-     1 string m_Localized = "Okay."
+     1 string m_Localized = "Alright."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -3662,7 +3662,7 @@
    [455]
     0 TableEntryData data
      0 SInt64 m_Id = 2838810659
-     1 string m_Localized = "I'm not letting you go!!!!!!!"
+     1 string m_Localized = "They're getting away!"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -6398,7 +6398,7 @@
    [797]
     0 TableEntryData data
      0 SInt64 m_Id = 55725795323076608
-     1 string m_Localized = "I think I can get past the guards if I hide behind this tar. ......"
+     1 string m_Localized = "I think I can sneak past the guards if I hide in this barrel..."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)


### PR DESCRIPTION
Progress from line [282] to [457]. Detoured to Altverden to save just after you escape from the Werne Stealth mission.

Its possible to cut short the conversation with Pohl if you fail the stealth portion too hard, and this might cause a soft-lock bug where-by Hildi fails to turn around and stare ominously at the command tent once the party escapes Werne.

[Main Scenario] >> [HeroTalk] inserts found:
- [346] >> [27]

Similar to Kyshiri Burning Event, Werne Stealth event has a bunch of throwaway MainScenario lines and 1 HeroTalk insert
- [353] to [361] >> [28]

- [370] >> [29]
- [389] >> [30]
- [391] >> [31] This is a guess. I couldn't proc the line.
- [444] >> [32}
- [449] >> [33]