### PR TITLE
Update Scenario_ch_00900_01_en Minor Fixes

### DIFF
--- a/text_DeepL/Scenario_ch_00900_01_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--4004182557547618371.txt
+++ b/text_DeepL/Scenario_ch_00900_01_en-CAB-a510f8427b6f727aa2cf8403abe0eca8--4004182557547618371.txt
@@ -198,7 +198,7 @@
    [22]
     0 TableEntryData data
      0 SInt64 m_Id = 3480539146
-     1 string m_Localized = "Yo, Noah. I've been hearing about you. You've built yourself a nice castle or town or something."
+     1 string m_Localized = "Yo, Nowa. I've been hearing about you. You've built yourself a nice castle or town or something."
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)
@@ -254,7 +254,7 @@
    [29]
     0 TableEntryData data
      0 SInt64 m_Id = 3480539153
-     1 string m_Localized = "Noah... right? Ah, you've made an alliance or something like that, right?"
+     1 string m_Localized = "Nowa... right? Ah, you've made an alliance or something like that, right?"
      0 MetadataCollection m_Metadata
       0 IMetadata m_Items
        0 Array Array (0 items)


### PR DESCRIPTION
Fixed mispelling of Nowa's name.